### PR TITLE
Introduce new prediction algorithms

### DIFF
--- a/examples/sandbox.rs
+++ b/examples/sandbox.rs
@@ -2,7 +2,8 @@ extern crate rsrl;
 
 use rsrl::{run, SerialExperiment, Evaluation};
 use rsrl::fa::linear::RBFNetwork;
-use rsrl::agents::control::td::QLearning;
+use rsrl::agents::prediction::td::TD;
+use rsrl::agents::control::actor_critic::ActorCritic;
 use rsrl::domains::{Domain, MountainCar};
 use rsrl::policies::{Greedy, EpsilonGreedy};
 use rsrl::geometry::Space;
@@ -18,8 +19,12 @@ fn main() {
 
         let q_func = RBFNetwork::new(
             domain.state_space().partitioned(8), n_actions);
+        let v_func = RBFNetwork::new(
+            domain.state_space().partitioned(8), 1);
 
-        QLearning::new(q_func, Greedy, 0.1, 0.95)
+        let critic = TD::new(v_func, 0.1, 0.99);
+
+        ActorCritic::new(q_func, critic, Greedy, 0.1, 0.99)
     };
 
     // Training:

--- a/examples/sandbox.rs
+++ b/examples/sandbox.rs
@@ -1,9 +1,9 @@
 extern crate rsrl;
 
 use rsrl::{run, SerialExperiment, Evaluation};
-use rsrl::fa::linear::UniformGrid;
+use rsrl::fa::linear::RBFNetwork;
 use rsrl::agents::control::td::QLearning;
-use rsrl::domains::{Domain, CartPole};
+use rsrl::domains::{Domain, MountainCar};
 use rsrl::policies::{Greedy, EpsilonGreedy};
 use rsrl::geometry::Space;
 
@@ -11,29 +11,29 @@ use rsrl::logging::DefaultLogger;
 
 
 fn main() {
-    let domain = CartPole::default();
+    let domain = MountainCar::default();
     let mut agent = {
         let aspace = domain.action_space();
         let n_actions: usize = aspace.span().into();
 
-        let q_func = UniformGrid::new(
-            domain.state_space().partitioned(10), n_actions);
+        let q_func = RBFNetwork::new(
+            domain.state_space().partitioned(8), n_actions);
 
-        QLearning::new(q_func, Greedy, 0.2, 0.95)
+        QLearning::new(q_func, Greedy, 0.1, 0.95)
     };
 
     // Training:
     let training_result = {
         let e = SerialExperiment::new(&mut agent,
-                                      Box::new(CartPole::default),
+                                      Box::new(MountainCar::default),
                                       1000);
 
-        run(e, 2000)
+        run(e, 1000)
     };
 
     // Testing:
     let testing_result =
-        Evaluation::new(&mut agent, Box::new(CartPole::default)).next().unwrap();
+        Evaluation::new(&mut agent, Box::new(MountainCar::default)).next().unwrap();
 
 
     println!("Solution \u{21D2} {} steps | reward {}",

--- a/src/agents/control/actor_critic.rs
+++ b/src/agents/control/actor_critic.rs
@@ -1,6 +1,6 @@
 use {Parameter};
 use fa::{VFunction, QFunction};
-use agents::{Agent, ControlAgent, PredictionAgent};
+use agents::{ControlAgent, PredictionAgent};
 use domains::Transition;
 use geometry::{Space, ActionSpace};
 use policies::{Policy, Greedy};
@@ -49,17 +49,6 @@ impl<S: Space, P: Policy, Q, C> ActorCritic<S, P, Q, C>
     }
 }
 
-impl<S: Space, P: Policy, Q, C> Agent<S> for ActorCritic<S, P, Q, C>
-    where Q: QFunction<S>,
-          C: PredictionAgent<S>
-{
-    fn handle_terminal(&mut self) {
-        self.alpha = self.alpha.step();
-        self.beta = self.beta.step();
-        self.gamma = self.gamma.step();
-    }
-}
-
 impl<S: Space, P: Policy, Q, C> ControlAgent<S, ActionSpace> for ActorCritic<S, P, Q, C>
     where Q: QFunction<S>,
           C: PredictionAgent<S>
@@ -78,5 +67,11 @@ impl<S: Space, P: Policy, Q, C> ControlAgent<S, ActionSpace> for ActorCritic<S, 
         let td_error = self.critic.handle_transition(s, ns, t.reward);
 
         self.actor.update_action(s, t.action, self.beta*td_error);
+    }
+
+    fn handle_terminal(&mut self, _: &S::Repr) {
+        self.alpha = self.alpha.step();
+        self.beta = self.beta.step();
+        self.gamma = self.gamma.step();
     }
 }

--- a/src/agents/control/actor_critic.rs
+++ b/src/agents/control/actor_critic.rs
@@ -17,7 +17,6 @@ pub struct ActorCritic<S: Space, P: Policy, Q, C>
 
     policy: P,
 
-    alpha: Parameter,
     beta: Parameter,
     gamma: Parameter,
 
@@ -28,11 +27,10 @@ impl<S: Space, P: Policy, Q, C> ActorCritic<S, P, Q, C>
     where Q: QFunction<S>,
           C: PredictionAgent<S>
 {
-    pub fn new<T1, T2, T3>(actor: Q, critic: C, policy: P,
-                           alpha: T1, beta: T2, gamma: T3) -> Self
+    pub fn new<T1, T2>(actor: Q, critic: C, policy: P,
+                           beta: T1, gamma: T2) -> Self
         where T1: Into<Parameter>,
-              T2: Into<Parameter>,
-              T3: Into<Parameter>
+              T2: Into<Parameter>
     {
         ActorCritic {
             actor: actor,
@@ -40,7 +38,6 @@ impl<S: Space, P: Policy, Q, C> ActorCritic<S, P, Q, C>
 
             policy: policy,
 
-            alpha: alpha.into(),
             beta: beta.into(),
             gamma: gamma.into(),
 
@@ -64,13 +61,12 @@ impl<S: Space, P: Policy, Q, C> ControlAgent<S, ActionSpace> for ActorCritic<S, 
     fn handle_transition(&mut self, t: &Transition<S, ActionSpace>) {
         let (s, ns) = (t.from.state(), t.to.state());
 
-        let td_error = self.critic.handle_transition(s, ns, t.reward);
+        let td_error = self.critic.handle_transition(s, ns, t.reward).unwrap();
 
         self.actor.update_action(s, t.action, self.beta*td_error);
     }
 
     fn handle_terminal(&mut self, _: &S::Repr) {
-        self.alpha = self.alpha.step();
         self.beta = self.beta.step();
         self.gamma = self.gamma.step();
     }

--- a/src/agents/control/mod.rs
+++ b/src/agents/control/mod.rs
@@ -1,12 +1,12 @@
-use super::Agent;
 use domains::Transition;
 use geometry::{Space, ActionSpace};
 
-pub trait ControlAgent<S: Space, A: Space>: Agent<S> {
+pub trait ControlAgent<S: Space, A: Space> {
     fn pi(&mut self, s: &S::Repr) -> usize;
     fn pi_target(&mut self, s: &S::Repr) -> usize;
 
     fn handle_transition(&mut self, t: &Transition<S, A>);
+    fn handle_terminal(&mut self, s: &S::Repr);
 }
 
 

--- a/src/agents/control/td.rs
+++ b/src/agents/control/td.rs
@@ -1,7 +1,7 @@
 use {Parameter};
 use fa::{VFunction, QFunction, Linear};
 use utils::dot;
-use agents::{Agent, ControlAgent};
+use agents::ControlAgent;
 use domains::Transition;
 use geometry::{Space, ActionSpace};
 use policies::{Policy, Greedy};
@@ -42,14 +42,6 @@ impl<S: Space, P: Policy, Q: QFunction<S>> QLearning<S, P, Q>
     }
 }
 
-impl<S: Space, P: Policy, Q: QFunction<S>> Agent<S> for QLearning<S, P, Q>
-{
-    fn handle_terminal(&mut self) {
-        self.alpha = self.alpha.step();
-        self.gamma = self.gamma.step();
-    }
-}
-
 impl<S: Space, P: Policy, Q: QFunction<S>> ControlAgent<S, ActionSpace> for QLearning<S, P, Q>
 {
     fn pi(&mut self, s: &S::Repr) -> usize {
@@ -72,6 +64,11 @@ impl<S: Space, P: Policy, Q: QFunction<S>> ControlAgent<S, ActionSpace> for QLea
         let td_error = self.alpha*(t.reward + self.gamma*nqs[na] - qs[a]);
 
         self.q_func.update_action(s, a, td_error);
+    }
+
+    fn handle_terminal(&mut self, _: &S::Repr) {
+        self.alpha = self.alpha.step();
+        self.gamma = self.gamma.step();
     }
 }
 
@@ -107,14 +104,6 @@ impl<S: Space, P: Policy, Q: QFunction<S>> SARSA<S, P, Q>
     }
 }
 
-impl<S: Space, P: Policy, Q: QFunction<S>> Agent<S> for SARSA<S, P, Q>
-{
-    fn handle_terminal(&mut self) {
-        self.alpha = self.alpha.step();
-        self.gamma = self.gamma.step();
-    }
-}
-
 impl<S: Space, P: Policy, Q: QFunction<S>> ControlAgent<S, ActionSpace> for SARSA<S, P, Q>
 {
     fn pi(&mut self, s: &S::Repr) -> usize {
@@ -137,6 +126,11 @@ impl<S: Space, P: Policy, Q: QFunction<S>> ControlAgent<S, ActionSpace> for SARS
         let td_error = self.alpha*(t.reward + self.gamma*nqs[na] - qs[a]);
 
         self.q_func.update_action(s, a, td_error);
+    }
+
+    fn handle_terminal(&mut self, _: &S::Repr) {
+        self.alpha = self.alpha.step();
+        self.gamma = self.gamma.step();
     }
 }
 
@@ -172,14 +166,6 @@ impl<S: Space, P: Policy, Q: QFunction<S>> ExpectedSARSA<S, P, Q>
     }
 }
 
-impl<S: Space, P: Policy, Q: QFunction<S>> Agent<S> for ExpectedSARSA<S, P, Q>
-{
-    fn handle_terminal(&mut self) {
-        self.alpha = self.alpha.step();
-        self.gamma = self.gamma.step();
-    }
-}
-
 impl<S: Space, P: Policy, Q: QFunction<S>> ControlAgent<S, ActionSpace> for ExpectedSARSA<S, P, Q>
 {
     fn pi(&mut self, s: &S::Repr) -> usize {
@@ -202,6 +188,11 @@ impl<S: Space, P: Policy, Q: QFunction<S>> ControlAgent<S, ActionSpace> for Expe
         let td_error = self.alpha*(t.reward + self.gamma*exp_nqs - qs[a]);
 
         self.q_func.update_action(s, a, td_error);
+    }
+
+    fn handle_terminal(&mut self, _: &S::Repr) {
+        self.alpha = self.alpha.step();
+        self.gamma = self.gamma.step();
     }
 }
 
@@ -241,17 +232,6 @@ impl<Q, V, P> GreedyGQ<Q, V, P> {
     }
 }
 
-impl<S: Space, Q, V, P: Policy> Agent<S> for GreedyGQ<Q, V, P>
-    where Q: QFunction<S> + Linear<S>,
-          V: VFunction<S> + Linear<S>
-{
-    fn handle_terminal(&mut self) {
-        self.alpha = self.alpha.step();
-        self.beta = self.beta.step();
-        self.gamma = self.gamma.step();
-    }
-}
-
 impl<S: Space, Q, V, P: Policy> ControlAgent<S, ActionSpace> for GreedyGQ<Q, V, P>
     where Q: QFunction<S> + Linear<S>,
           V: VFunction<S> + Linear<S>
@@ -280,5 +260,11 @@ impl<S: Space, Q, V, P: Policy> ControlAgent<S, ActionSpace> for GreedyGQ<Q, V, 
 
         self.q_func.update_action_phi(&update_q, a, self.alpha.value());
         self.v_func.update_phi(&update_v, self.alpha*self.beta);
+    }
+
+    fn handle_terminal(&mut self, _: &S::Repr) {
+        self.alpha = self.alpha.step();
+        self.beta = self.beta.step();
+        self.gamma = self.gamma.step();
     }
 }

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -1,10 +1,6 @@
 use geometry::Space;
 
 
-pub trait Agent<S: Space> {
-    fn handle_terminal(&mut self) {}
-}
-
 pub use self::control::ControlAgent;
 pub use self::prediction::PredictionAgent;
 

--- a/src/agents/prediction/mc.rs
+++ b/src/agents/prediction/mc.rs
@@ -1,0 +1,60 @@
+use Parameter;
+use fa::VFunction;
+use agents::PredictionAgent;
+use geometry::Space;
+use std::marker::PhantomData;
+
+use ndarray::ArrayBase;
+
+
+pub struct EveryVisitMC<S: Space, V: VFunction<S>>
+{
+    v_func: V,
+    observations: Vec<(S::Repr, f64)>,
+
+    alpha: Parameter,
+    gamma: Parameter,
+
+    phantom: PhantomData<S>,
+}
+
+impl<S: Space, V: VFunction<S>> EveryVisitMC<S, V>
+{
+    pub fn new<T1, T2>(v_func: V, alpha: T1, gamma: T2) -> Self
+        where T1: Into<Parameter>,
+              T2: Into<Parameter>
+    {
+        EveryVisitMC {
+            v_func: v_func,
+            observations: vec![],
+
+            alpha: alpha.into(),
+            gamma: gamma.into(),
+
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<S: Space, V: VFunction<S>> PredictionAgent<S> for EveryVisitMC<S, V>
+{
+    fn handle_transition(&mut self, s: &S::Repr, _: &S::Repr, r: f64) -> Option<f64> {
+        self.observations.push((s.clone(), r));
+
+        None
+    }
+
+    fn handle_terminal(&mut self, _: &S::Repr) {
+        let mut sum = 0.0;
+
+        for (s, r) in self.observations.drain(0..).rev() {
+            sum = r + self.gamma*sum;
+
+            let v_est = self.v_func.evaluate(&s);
+            self.v_func.update(&s, self.alpha*(sum - v_est));
+        }
+
+        self.alpha = self.alpha.step();
+        self.gamma = self.gamma.step();
+    }
+}

--- a/src/agents/prediction/mod.rs
+++ b/src/agents/prediction/mod.rs
@@ -2,7 +2,7 @@ use geometry::{Space, NullSpace};
 
 
 pub trait PredictionAgent<S: Space> {
-    fn handle_transition(&mut self, s: &S::Repr, ns: &S::Repr, r: f64) -> f64;
+    fn handle_transition(&mut self, s: &S::Repr, ns: &S::Repr, r: f64) -> Option<f64>;
     fn handle_terminal(&mut self, s: &S::Repr);
 }
 

--- a/src/agents/prediction/mod.rs
+++ b/src/agents/prediction/mod.rs
@@ -8,3 +8,4 @@ pub trait PredictionAgent<S: Space> {
 
 
 pub mod td;
+pub mod mc;

--- a/src/agents/prediction/mod.rs
+++ b/src/agents/prediction/mod.rs
@@ -1,9 +1,9 @@
-use super::Agent;
 use geometry::{Space, NullSpace};
 
 
-pub trait PredictionAgent<S: Space>: Agent<S> {
+pub trait PredictionAgent<S: Space> {
     fn handle_transition(&mut self, s: &S::Repr, ns: &S::Repr, r: f64) -> f64;
+    fn handle_terminal(&mut self, s: &S::Repr);
 }
 
 

--- a/src/agents/prediction/td.rs
+++ b/src/agents/prediction/td.rs
@@ -96,13 +96,74 @@ impl<S: Space, V: VFunction<S> + Linear<S>> PredictionAgent<S> for GTD2<S, V>
         let phi_s = self.v_func.phi(s);
         let phi_ns = self.v_func.phi(ns);
 
+        let td_error = r + self.gamma*self.v_func.evaluate_phi(&phi_ns) -
+            self.v_func.evaluate_phi(&phi_s);
+        let td_estimate = self.a_func.evaluate_phi(&phi_s);
+
+        self.v_func.update_phi(&(&phi_s - &(self.gamma.value()*&phi_ns)), self.alpha*td_estimate);
+        self.a_func.update_phi(&phi_s, self.beta*(td_error - td_estimate));
+
+        Some(td_error)
+    }
+
+    fn handle_terminal(&mut self, _: &S::Repr) {
+        self.alpha = self.alpha.step();
+        self.beta = self.alpha.step();
+        self.gamma = self.gamma.step();
+    }
+}
+
+
+pub struct TDC<S: Space, V: VFunction<S> + Linear<S>>
+{
+    v_func: V,
+    a_func: V,
+
+    alpha: Parameter,
+    beta: Parameter,
+    gamma: Parameter,
+
+    phantom: PhantomData<S>,
+}
+
+impl<S: Space, V: VFunction<S> + Linear<S>> TDC<S, V>
+{
+    pub fn new<T1, T2, T3>(v_func: V, a_func: V,
+                           alpha: T1, beta: T2, gamma: T3) -> Self
+        where T1: Into<Parameter>,
+              T2: Into<Parameter>,
+              T3: Into<Parameter>
+    {
+        if !v_func.equivalent(&a_func) {
+            panic!("v_func and a_func must be equivalent function approximators.")
+        }
+
+        TDC {
+            v_func: v_func,
+            a_func: a_func,
+
+            alpha: alpha.into(),
+            beta: beta.into(),
+            gamma: gamma.into(),
+
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<S: Space, V: VFunction<S> + Linear<S>> PredictionAgent<S> for TDC<S, V>
+{
+    fn handle_transition(&mut self, s: &S::Repr, ns: &S::Repr, r: f64) -> Option<f64> {
+        let phi_s = self.v_func.phi(s);
+        let phi_ns = self.v_func.phi(ns);
+
         let phi_diff = &phi_s - &(self.gamma.value()*&phi_ns);
 
         let td_error = r + self.gamma*self.v_func.evaluate_phi(&phi_ns) -
             self.v_func.evaluate_phi(&phi_s);
         let td_estimate = self.a_func.evaluate_phi(&phi_s);
 
-        self.v_func.update_phi(&phi_diff, self.alpha*td_estimate);
+        self.v_func.update_phi(&(&(td_estimate*&phi_s) - &(self.gamma.value()*td_estimate*&phi_ns)), self.alpha.value());
         self.a_func.update_phi(&phi_s, self.beta*(td_error - td_estimate));
 
         Some(td_error)

--- a/src/agents/prediction/td.rs
+++ b/src/agents/prediction/td.rs
@@ -1,6 +1,6 @@
 use Parameter;
 use fa::VFunction;
-use agents::{Agent, PredictionAgent};
+use agents::PredictionAgent;
 use geometry::{Space, NullSpace};
 use std::marker::PhantomData;
 
@@ -32,14 +32,6 @@ impl<S: Space, V: VFunction<S>> TD<S, V>
     }
 }
 
-impl<S: Space, V: VFunction<S>> Agent<S> for TD<S, V>
-{
-    fn handle_terminal(&mut self) {
-        self.alpha = self.alpha.step();
-        self.gamma = self.gamma.step();
-    }
-}
-
 impl<S: Space, V: VFunction<S>> PredictionAgent<S> for TD<S, V>
 {
     fn handle_transition(&mut self, s: &S::Repr, ns: &S::Repr, r: f64) -> f64 {
@@ -50,5 +42,10 @@ impl<S: Space, V: VFunction<S>> PredictionAgent<S> for TD<S, V>
         self.v_func.update(&s, td_error);
 
         td_error
+    }
+
+    fn handle_terminal(&mut self, _: &S::Repr) {
+        self.alpha = self.alpha.step();
+        self.gamma = self.gamma.step();
     }
 }

--- a/src/agents/prediction/td.rs
+++ b/src/agents/prediction/td.rs
@@ -34,14 +34,14 @@ impl<S: Space, V: VFunction<S>> TD<S, V>
 
 impl<S: Space, V: VFunction<S>> PredictionAgent<S> for TD<S, V>
 {
-    fn handle_transition(&mut self, s: &S::Repr, ns: &S::Repr, r: f64) -> f64 {
+    fn handle_transition(&mut self, s: &S::Repr, ns: &S::Repr, r: f64) -> Option<f64> {
         let v = self.v_func.evaluate(s);
         let nv = self.v_func.evaluate(ns);
 
         let td_error = self.alpha*(r + self.gamma*nv - v);
         self.v_func.update(&s, td_error);
 
-        td_error
+        Some(td_error)
     }
 
     fn handle_terminal(&mut self, _: &S::Repr) {

--- a/src/agents/prediction/td.rs
+++ b/src/agents/prediction/td.rs
@@ -4,6 +4,8 @@ use agents::PredictionAgent;
 use geometry::{Space, NullSpace};
 use std::marker::PhantomData;
 
+use ndarray::ArrayBase;
+
 
 pub struct TD<S: Space, V: VFunction<S>>
 {
@@ -46,6 +48,69 @@ impl<S: Space, V: VFunction<S>> PredictionAgent<S> for TD<S, V>
 
     fn handle_terminal(&mut self, _: &S::Repr) {
         self.alpha = self.alpha.step();
+        self.gamma = self.gamma.step();
+    }
+}
+
+
+pub struct GTD2<S: Space, V: VFunction<S> + Linear<S>>
+{
+    v_func: V,
+    a_func: V,
+
+    alpha: Parameter,
+    beta: Parameter,
+    gamma: Parameter,
+
+    phantom: PhantomData<S>,
+}
+
+impl<S: Space, V: VFunction<S> + Linear<S>> GTD2<S, V>
+{
+    pub fn new<T1, T2, T3>(v_func: V, a_func: V,
+                           alpha: T1, beta: T2, gamma: T3) -> Self
+        where T1: Into<Parameter>,
+              T2: Into<Parameter>,
+              T3: Into<Parameter>
+    {
+        if !v_func.equivalent(&a_func) {
+            panic!("v_func and a_func must be equivalent function approximators.")
+        }
+
+        GTD2 {
+            v_func: v_func,
+            a_func: a_func,
+
+            alpha: alpha.into(),
+            beta: beta.into(),
+            gamma: gamma.into(),
+
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<S: Space, V: VFunction<S> + Linear<S>> PredictionAgent<S> for GTD2<S, V>
+{
+    fn handle_transition(&mut self, s: &S::Repr, ns: &S::Repr, r: f64) -> Option<f64> {
+        let phi_s = self.v_func.phi(s);
+        let phi_ns = self.v_func.phi(ns);
+
+        let phi_diff = &phi_s - &(self.gamma.value()*&phi_ns);
+
+        let td_error = r + self.gamma*self.v_func.evaluate_phi(&phi_ns) -
+            self.v_func.evaluate_phi(&phi_s);
+        let td_estimate = self.a_func.evaluate_phi(&phi_s);
+
+        self.v_func.update_phi(&phi_diff, self.alpha*td_estimate);
+        self.a_func.update_phi(&phi_s, self.beta*(td_error - td_estimate));
+
+        Some(td_error)
+    }
+
+    fn handle_terminal(&mut self, _: &S::Repr) {
+        self.alpha = self.alpha.step();
+        self.beta = self.alpha.step();
         self.gamma = self.gamma.step();
     }
 }

--- a/src/agents/prediction/td.rs
+++ b/src/agents/prediction/td.rs
@@ -1,5 +1,5 @@
 use Parameter;
-use fa::VFunction;
+use fa::{VFunction, Linear};
 use agents::PredictionAgent;
 use geometry::{Space, NullSpace};
 use std::marker::PhantomData;
@@ -38,8 +38,8 @@ impl<S: Space, V: VFunction<S>> PredictionAgent<S> for TD<S, V>
         let v = self.v_func.evaluate(s);
         let nv = self.v_func.evaluate(ns);
 
-        let td_error = self.alpha*(r + self.gamma*nv - v);
-        self.v_func.update(&s, td_error);
+        let td_error = r + self.gamma*nv - v;
+        self.v_func.update(&s, self.alpha*td_error);
 
         Some(td_error)
     }

--- a/src/experiment.rs
+++ b/src/experiment.rs
@@ -80,7 +80,10 @@ impl<'a, S: Space, A, D> Iterator for Evaluation<'a, A, D>
             e.total_reward += t.reward;
 
             a = match t.to {
-                Observation::Terminal(_) => break,
+                Observation::Terminal(ref s) => {
+                    self.agent.handle_terminal(s);
+                    break;
+                },
                 _ => self.agent.pi(&t.to.state())
             };
         }
@@ -138,7 +141,10 @@ impl<'a, S: Space, A, D> Iterator for SerialExperiment<'a, A, D>
             self.agent.handle_transition(&t);
 
             a = match t.to {
-                Observation::Terminal(_) => break,
+                Observation::Terminal(ref s) => {
+                    self.agent.handle_terminal(s);
+                    break;
+                },
                 _ => self.agent.pi(&t.to.state())
             };
         }

--- a/src/fa/basis_network.rs
+++ b/src/fa/basis_network.rs
@@ -78,6 +78,10 @@ impl Parameterised<Vec<f64>, f64> for BasisNetwork {
         // Update the weights via addassign:
         self.weights.scaled_add(error, &phi);
     }
+
+    fn equivalent(&self, other: &Self) -> bool {
+        unimplemented!()
+    }
 }
 
 impl Parameterised<Vec<f64>, Vec<f64>> for BasisNetwork
@@ -92,6 +96,10 @@ impl Parameterised<Vec<f64>, Vec<f64>> for BasisNetwork
 
         // Update the weights via addassign:
         self.weights += &phi.dot(&update_matrix)
+    }
+
+    fn equivalent(&self, other: &Self) -> bool {
+        <Self as Parameterised<Vec<f64>, f64>>::equivalent(self, other)
     }
 }
 

--- a/src/fa/fgroup.rs
+++ b/src/fa/fgroup.rs
@@ -29,6 +29,11 @@ impl<S: Space, V: VFunction<S>> Parameterised<S::Repr, Vec<f64>> for VFunctionGr
             index += 1;
         }
     }
+
+    fn equivalent(&self, other: &Self) -> bool {
+        self.0.iter().zip(other.0.iter())
+            .any(|(ref f1, ref f2)| !f1.equivalent(f2))
+    }
 }
 
 impl<S: Space, V: VFunction<S>> QFunction<S> for VFunctionGroup<S, V>
@@ -58,6 +63,7 @@ mod tests {
 
     impl Parameterised<Vec<f64>, f64> for Mock {
         fn update(&mut self, _: &Vec<f64>, e: f64) { self.0 = e; }
+        fn equivalent(&self, other: &Self) -> bool { self.0 == other.0 }
     }
 
     impl VFunction<RegularSpace<Continuous>> for Mock {}

--- a/src/fa/mod.rs
+++ b/src/fa/mod.rs
@@ -19,6 +19,7 @@ impl<I: ?Sized, O, T> Function<I, O> for Box<T>
 /// An interface for dealing with adaptive functions.
 pub trait Parameterised<I: ?Sized, E> {
     fn update(&mut self, input: &I, error: E);
+    fn equivalent(&self, other: &Self) -> bool;
 }
 
 impl<I: ?Sized, E, T> Parameterised<I, E> for Box<T>
@@ -26,6 +27,10 @@ impl<I: ?Sized, E, T> Parameterised<I, E> for Box<T>
 {
     fn update(&mut self, input: &I, error: E) {
         (**self).update(input, error)
+    }
+
+    fn equivalent(&self, other: &Self) -> bool {
+        (**self).equivalent(other)
     }
 }
 

--- a/src/fa/rbf_network.rs
+++ b/src/fa/rbf_network.rs
@@ -74,6 +74,12 @@ impl Parameterised<Vec<f64>, f64> for RBFNetwork
 
         <Self as VFunction<RegularSpace<Continuous>>>::update_phi(self, &phi, error);
     }
+
+    fn equivalent(&self, other: &Self) -> bool {
+        self.mu == other.mu &&
+            self.gamma == self.gamma &&
+            self.weights.shape() == other.weights.shape()
+    }
 }
 
 impl Parameterised<Vec<f64>, Vec<f64>> for RBFNetwork
@@ -83,6 +89,10 @@ impl Parameterised<Vec<f64>, Vec<f64>> for RBFNetwork
         let phi = self.phi(input);
 
         <Self as QFunction<RegularSpace<Continuous>>>::update_phi(self, &phi, errors);
+    }
+
+    fn equivalent(&self, other: &Self) -> bool {
+        <Self as Parameterised<Vec<f64>, f64>>::equivalent(self, other)
     }
 }
 

--- a/src/fa/sutton_tiles.rs
+++ b/src/fa/sutton_tiles.rs
@@ -80,6 +80,13 @@ impl Parameterised<Vec<f64>, f64> for SuttonTiles {
             self.weights[t] += error;
         }
     }
+
+    fn equivalent(&self, other: &Self) -> bool {
+        self.weights.shape() == other.weights.shape() &&
+            self.n_outputs == other.n_outputs &&
+            self.n_tilings == other.n_tilings &&
+            self.memory_size == other.memory_size
+    }
 }
 
 impl Parameterised<Vec<f64>, Vec<f64>> for SuttonTiles {
@@ -87,6 +94,10 @@ impl Parameterised<Vec<f64>, Vec<f64>> for SuttonTiles {
         for c in 0..self.n_outputs {
             <Self as QFunction<RegularSpace<Continuous>>>::update_action(self, input, c, errors[c]);
         }
+    }
+
+    fn equivalent(&self, other: &Self) -> bool {
+        <Self as Parameterised<Vec<f64>, f64>>::equivalent(self, other)
     }
 }
 

--- a/src/fa/table.rs
+++ b/src/fa/table.rs
@@ -55,4 +55,6 @@ impl<I, E> Parameterised<I, E> for Table<I, E>
     fn update(&mut self, input: &I, error: E) {
         *self.0.entry(*input).or_insert(E::default()) += error;
     }
+
+    fn equivalent(&self, other: &Self) -> bool { true }
 }

--- a/src/fa/uniform_grid.rs
+++ b/src/fa/uniform_grid.rs
@@ -69,6 +69,10 @@ impl Parameterised<Vec<f64>, f64> for UniformGrid {
             *self.weights.uget_mut((index, 0)) += error
         }
     }
+
+    fn equivalent(&self, other: &Self) -> bool {
+        self.weights.shape() == other.weights.shape()
+    }
 }
 
 impl Parameterised<Vec<f64>, Vec<f64>> for UniformGrid {
@@ -78,6 +82,10 @@ impl Parameterised<Vec<f64>, Vec<f64>> for UniformGrid {
 
         // Get the row slice and perform update via memcpy:
         self.weights.row_mut(ri).scaled_add(1.0, &arr1(&errors));
+    }
+
+    fn equivalent(&self, other: &Self) -> bool {
+        <Self as Parameterised<Vec<f64>, f64>>::equivalent(self, other)
     }
 }
 

--- a/src/geometry/dimensions.rs
+++ b/src/geometry/dimensions.rs
@@ -330,7 +330,7 @@ mod tests {
         let d = Infinite;
         let mut rng = thread_rng();
 
-        let s = d.sample(&mut rng);
+        let _ = d.sample(&mut rng);
     }
 
     #[test]

--- a/src/geometry/dimensions.rs
+++ b/src/geometry/dimensions.rs
@@ -12,7 +12,7 @@ use rand::distributions::{Range as RngRange, IndependentSample};
 pub trait Dimension
 {
     /// The corresponding primitive type.
-    type Value;
+    type Value: Clone;
 
     /// Sample a random value contained by this dimension.
     fn sample(&self, rng: &mut ThreadRng) -> Self::Value;

--- a/src/geometry/spaces.rs
+++ b/src/geometry/spaces.rs
@@ -8,7 +8,7 @@ use super::dimensions::{Dimension, Partitioned};
 
 
 pub trait Space {
-    type Repr;
+    type Repr: Clone;
 
     fn sample(&self, rng: &mut ThreadRng) -> Self::Repr;
 

--- a/src/geometry/span.rs
+++ b/src/geometry/span.rs
@@ -81,14 +81,14 @@ mod tests {
     #[should_panic]
     fn test_into_null() {
         let s = Span::Null;
-        let v: usize = s.into();
+        let _: usize = s.into();
     }
 
     #[test]
     #[should_panic]
     fn test_into_infinite() {
         let s = Span::Infinite;
-        let v: usize = s.into();
+        let _: usize = s.into();
     }
 
     #[test]


### PR DESCRIPTION
This PR adds a selection of new algorithms to the agents::prediction module. These include:

1. **TDC** - _corrected_ temporal difference learning
2. **GTD2** - gradient temporal difference learning (v2)
3. **EveryVisitMC**

These have been implemented based on the specification from the excellent book "[Algorithms for Reinforcement Learning](https://sites.ualberta.ca/~szepesva/RLBook.html)" by Csaba Szepesvári.

As part of these changes, a new method `equivalent` was added to the `Parameterised` trait which compares the form of the function approximator (FA). Though very similar to the `PartialEq` and `Eq` built-in traits, this method does not compare weight values, just their representation. This is particularly relevant when using linear function approximation and require two FAs to have the same feature mapping.