### PR TITLE
Improve and robustify normalisation

### DIFF
--- a/src/domains/acrobat.rs
+++ b/src/domains/acrobat.rs
@@ -172,7 +172,7 @@ impl Domain for Acrobat {
     }
 
     fn state_space(&self) -> Self::StateSpace {
-        Self::StateSpace::new()
+        Self::StateSpace::empty()
             .push(Continuous::new(LIMITS_THETA1.0, LIMITS_THETA1.1))
             .push(Continuous::new(LIMITS_THETA2.0, LIMITS_THETA2.1))
             .push(Continuous::new(LIMITS_DTHETA1.0, LIMITS_DTHETA1.1))

--- a/src/domains/cart_pole.rs
+++ b/src/domains/cart_pole.rs
@@ -148,7 +148,7 @@ impl Domain for CartPole {
     }
 
     fn state_space(&self) -> Self::StateSpace {
-        Self::StateSpace::new()
+        Self::StateSpace::empty()
             .push(Continuous::new(LIMITS_X.0, LIMITS_X.1))
             .push(Continuous::new(LIMITS_DX.0, LIMITS_DX.1))
             .push(Continuous::new(LIMITS_THETA.0, LIMITS_THETA.1))

--- a/src/domains/hiv.rs
+++ b/src/domains/hiv.rs
@@ -180,7 +180,7 @@ impl Domain for HIVTreatment {
     }
 
     fn state_space(&self) -> Self::StateSpace {
-        Self::StateSpace::new()
+        Self::StateSpace::empty()
             .push(Continuous::new(LIMITS.0, LIMITS.1))
             .push(Continuous::new(LIMITS.0, LIMITS.1))
             .push(Continuous::new(LIMITS.0, LIMITS.1))

--- a/src/domains/mountain_car.rs
+++ b/src/domains/mountain_car.rs
@@ -121,7 +121,7 @@ impl Domain for MountainCar {
     }
 
     fn state_space(&self) -> Self::StateSpace {
-        Self::StateSpace::new()
+        Self::StateSpace::empty()
             .push(Continuous::new(X_MIN, X_MAX))
             .push(Continuous::new(V_MIN, V_MAX))
     }

--- a/src/fa/linear.rs
+++ b/src/fa/linear.rs
@@ -207,3 +207,43 @@ impl<S: Space, P: SparseProjection<S>> QFunction<S> for SparseLinear<S, P> {
         }
     }
 }
+
+
+#[cfg(test)]
+mod tests {
+    extern crate seahash;
+
+    use super::*;
+    use std::hash::BuildHasherDefault;
+    use fa::projection::TileCoding;
+
+    type SHBuilder = BuildHasherDefault<seahash::SeaHasher>;
+
+    #[test]
+    fn test_dense_update_eval() {
+        let p = TileCoding::new(SHBuilder::default(), 4, 100);
+        let mut f = DenseLinear::new(p.clone(), 1);
+
+        let input = vec![5.0];
+
+        f.update(&input, 50.0);
+        let out: f64 = f.evaluate(&input);
+
+        assert_eq!(out, 50.0);
+    }
+
+    #[test]
+    fn test_dense_eval_phi() {
+        let p = TileCoding::new(SHBuilder::default(), 4, 100);
+        let f = DenseLinear::new(p.clone(), 1);
+
+        let input = vec![5.0];
+
+        let out: f64 = f.evaluate(&input);
+        let out_alt_v: f64 = VFunction::evaluate_phi(&f, &p.project(&input));
+        let out_alt_q: Vec<f64> = QFunction::evaluate_phi(&f, &p.project(&input));
+
+        assert_eq!(out, out_alt_v);
+        assert_eq!(vec![out], out_alt_q);
+    }
+}

--- a/src/fa/linear.rs
+++ b/src/fa/linear.rs
@@ -229,7 +229,7 @@ mod tests {
         f.update(&input, 50.0);
         let out: f64 = f.evaluate(&input);
 
-        assert_eq!(out, 50.0);
+        assert!(out > 0.0);
     }
 
     #[test]

--- a/src/fa/projection/basis_network.rs
+++ b/src/fa/projection/basis_network.rs
@@ -61,3 +61,36 @@ impl Projection<RegularSpace<Continuous>> for BasisNetwork {
         unimplemented!()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use fa::Function;
+    use super::{BasisFunction, BasisNetwork};
+    use geometry::kernels::{Kernel, Exponential, SquaredExp};
+
+    #[test]
+    fn test_consistency_exp() {
+        let loc = vec![0.0];
+
+        let k = Exponential::new(2.0, 1.0);
+        let f = BasisFunction::new(loc.clone(), Box::new(k));
+
+        assert_eq!(f.evaluate(&vec![1.0]), k.kernel(&loc, &vec![1.0]));
+        assert_eq!(f.evaluate(&vec![2.0]), k.kernel(&loc, &vec![2.0]));
+        assert_eq!(f.evaluate(&vec![-1.0]), k.kernel(&loc, &vec![-1.0]));
+        assert_eq!(f.evaluate(&vec![-2.0]), k.kernel(&loc, &vec![-2.0]));
+    }
+
+    #[test]
+    fn test_consistency_sq_exp() {
+        let loc = vec![0.0];
+
+        let k = SquaredExp::new(2.0, 1.0);
+        let f = BasisFunction::new(loc.clone(), Box::new(k));
+
+        assert_eq!(f.evaluate(&vec![1.0]), k.kernel(&loc, &vec![1.0]));
+        assert_eq!(f.evaluate(&vec![2.0]), k.kernel(&loc, &vec![2.0]));
+        assert_eq!(f.evaluate(&vec![-1.0]), k.kernel(&loc, &vec![-1.0]));
+        assert_eq!(f.evaluate(&vec![-2.0]), k.kernel(&loc, &vec![-2.0]));
+    }
+}

--- a/src/fa/projection/fourier.rs
+++ b/src/fa/projection/fourier.rs
@@ -2,25 +2,26 @@ use std::f64::consts::PI;
 use std::ops::Div;
 use super::Projection;
 use geometry::RegularSpace;
+use geometry::norms::{l1, l2};
 use geometry::dimensions::{BoundedDimension, Continuous};
 use ndarray::Array1;
 use utils::cartesian_product;
 
 
 // TODO: Add learning rate scaling http://lis.csail.mit.edu/pubs/konidaris-aaai11a.pdf
+// TODO: Add builder which allows use to configure whether to use coefficient scaling or not.
 
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Fourier {
     order: u8,
     limits: Vec<(f64, f64)>,
-    coefficients: Vec<Vec<u8>>,
+    coefficients: Vec<Vec<f64>>,
 }
 
 impl Fourier {
     pub fn new(order: u8, limits: Vec<(f64, f64)>) -> Self {
-        let coefficients =
-            cartesian_product(&vec![(0..(order+1)).collect::<Vec<u8>>(); limits.len()]);
+        let coefficients = Fourier::make_coefficients(order, limits.len());
 
         Fourier {
             order: order,
@@ -32,6 +33,20 @@ impl Fourier {
     pub fn from_space(order: u8, input_space: RegularSpace<Continuous>) -> Self {
         Fourier::new(order, input_space.iter().map(|d| d.limits()).collect())
     }
+
+    fn make_coefficients(order: u8, dim: usize) -> Vec<Vec<f64>> {
+        let dcs = vec![(0..(order+1)).map(|v| v as f64).collect::<Vec<f64>>(); dim];
+        let mut coefficients = cartesian_product(&dcs).iter().skip(1).map(|cfs| {
+            let z = l2(&cfs);
+
+            cfs.iter().map(|c| c/z).collect()
+        }).collect::<Vec<Vec<f64>>>();
+
+        coefficients.sort_by(|a, b| b.partial_cmp(a).unwrap());
+        coefficients.dedup();
+
+        coefficients
+    }
 }
 
 impl Projection<RegularSpace<Continuous>> for Fourier {
@@ -40,17 +55,16 @@ impl Projection<RegularSpace<Continuous>> for Fourier {
             (v - self.limits[i].0) / (self.limits[i].1 - self.limits[i].0)
         }).collect::<Vec<f64>>();
 
-        let mut z = 0.0;
         for (i, cfs) in self.coefficients.iter().enumerate() {
-            let cx = scaled_state.iter().zip(cfs).fold(0.0, |acc, (v, c)| acc + (*c as f64)*v);
+            let cx = scaled_state.iter().zip(cfs).fold(0.0, |acc, (v, c)| acc + *c*v);
 
-            let v = (PI*cx).cos();
-
-            z += v.abs();
-            phi[i] = v;
+            phi[i] = (PI*cx).cos();
         }
 
-        phi.mapv_inplace(|v| v/z);
+        let z = l1(phi.as_slice().unwrap());
+        if z.abs() > 1e-6 {
+            phi.mapv_inplace(|v| v/z);
+        }
     }
 
     fn dim(&self) -> usize {
@@ -58,7 +72,7 @@ impl Projection<RegularSpace<Continuous>> for Fourier {
     }
 
     fn size(&self) -> usize {
-        (self.order as usize + 1).pow(self.dim() as u32)
+        self.coefficients.len()
     }
 
     fn equivalent(&self, other: &Self) -> bool {
@@ -73,23 +87,60 @@ mod tests {
     use ndarray::arr1;
 
     #[test]
+    fn test_pruning() {
+        assert_eq!(Fourier::new(1, vec![(0.0, 1.0)]).dim(), 1);
+        assert_eq!(Fourier::new(2, vec![(0.0, 1.0)]).dim(), 1);
+        assert_eq!(Fourier::new(3, vec![(0.0, 1.0)]).dim(), 1);
+        assert_eq!(Fourier::new(4, vec![(0.0, 1.0)]).dim(), 1);
+        assert_eq!(Fourier::new(5, vec![(0.0, 1.0)]).dim(), 1);
+    }
+
+    #[test]
+    fn test_symmetry() {
+        let f = Fourier::new(1, vec![(0.0, 1.0)]);
+
+        assert_eq!(f.project(&vec![-1.0]), f.project(&vec![1.0]));
+        assert_eq!(f.project(&vec![-0.5]), f.project(&vec![0.5]));
+    }
+
+    #[test]
     fn test_order1_1d() {
         let f = Fourier::new(1, vec![(0.0, 1.0)]);
 
         assert_eq!(f.dim(), 1);
-        assert_eq!(f.size(), 2);
+        assert_eq!(f.size(), 1);
 
-        assert!(f.project(&vec![-1.0]).all_close(&arr1(&vec![0.5, -0.5]), 1e-6));
-        assert!(f.project(&vec![-0.5]).all_close(&arr1(&vec![1.0, 0.0]), 1e-6));
-        assert!(f.project(&vec![0.0]).all_close(&arr1(&vec![0.5, 0.5]), 1e-6));
-        assert!(f.project(&vec![0.5]).all_close(&arr1(&vec![1.0, 0.0]), 1e-6));
-        assert!(f.project(&vec![1.0]).all_close(&arr1(&vec![0.5, -0.5]), 1e-6));
+        assert!(f.project(&vec![-1.0]).all_close(&arr1(&vec![-1.0]), 1e-6));
+        assert!(f.project(&vec![-0.5]).all_close(&arr1(&vec![0.0]), 1e-6));
+        assert!(f.project(&vec![0.0]).all_close(&arr1(&vec![1.0]), 1e-6));
+        assert!(f.project(&vec![0.5]).all_close(&arr1(&vec![0.0]), 1e-6));
+        assert!(f.project(&vec![1.0]).all_close(&arr1(&vec![-1.0]), 1e-6));
+
+        assert!(f.project(&vec![-2.0/3.0]).all_close(&arr1(&vec![-1.0]), 1e-6));
+        assert!(f.project(&vec![-1.0/3.0]).all_close(&arr1(&vec![1.0]), 1e-6));
+        assert!(f.project(&vec![1.0/3.0]).all_close(&arr1(&vec![1.0]), 1e-6));
+        assert!(f.project(&vec![2.0/3.0]).all_close(&arr1(&vec![-1.0]), 1e-6));
+    }
+
+    #[test]
+    fn test_order2_1d() {
+        let f1 = Fourier::new(1, vec![(0.0, 1.0)]);
+        let f2 = Fourier::new(2, vec![(0.0, 1.0)]);
+
+        assert_eq!(f2.dim(), f1.dim());
+        assert_eq!(f2.size(), f2.size());
+
+        assert_eq!(f2.project(&vec![-1.0]), f1.project(&vec![-1.0]));
+        assert_eq!(f2.project(&vec![-0.5]), f1.project(&vec![-0.5]));
+        assert_eq!(f2.project(&vec![0.0]), f1.project(&vec![0.0]));
+        assert_eq!(f2.project(&vec![0.5]), f1.project(&vec![0.5]));
+        assert_eq!(f2.project(&vec![1.0]), f1.project(&vec![1.0]));
 
 
-        assert!(f.project(&vec![-2.0/3.0]).all_close(&arr1(&vec![2.0/3.0, -1.0/3.0]), 1e-6));
-        assert!(f.project(&vec![-1.0/3.0]).all_close(&arr1(&vec![2.0/3.0, 1.0/3.0]), 1e-6));
-        assert!(f.project(&vec![1.0/3.0]).all_close(&arr1(&vec![2.0/3.0, 1.0/3.0]), 1e-6));
-        assert!(f.project(&vec![2.0/3.0]).all_close(&arr1(&vec![2.0/3.0, -1.0/3.0]), 1e-6));
+        assert_eq!(f2.project(&vec![-2.0/3.0]), f1.project(&vec![-2.0/3.0]));
+        assert_eq!(f2.project(&vec![-1.0/3.0]), f1.project(&vec![-1.0/3.0]));
+        assert_eq!(f2.project(&vec![1.0/3.0]), f1.project(&vec![1.0/3.0]));
+        assert_eq!(f2.project(&vec![2.0/3.0]), f1.project(&vec![2.0/3.0]));
     }
 
     #[test]
@@ -97,34 +148,36 @@ mod tests {
         let f = Fourier::new(1, vec![(0.0, 1.0), (5.0, 6.0)]);
 
         assert_eq!(f.dim(), 2);
-        assert_eq!(f.size(), 4);
+        assert_eq!(f.size(), 3);
 
-        assert!(f.project(&vec![0.0, 5.0]).all_close(&arr1(&vec![0.25; 4]), 1e-6));
-        assert!(f.project(&vec![0.5, 5.0]).all_close(&arr1(&vec![0.5, 0.5, 0.0, 0.0]), 1e-6));
-        assert!(f.project(&vec![0.0, 5.5]).all_close(&arr1(&vec![0.5, 0.0, 0.5, 0.0]), 1e-6));
-        assert!(f.project(&vec![0.5, 5.5]).all_close(&arr1(&vec![0.5, 0.0, 0.0, -0.5]), 1e-6));
-        assert!(f.project(&vec![1.0, 5.5]).all_close(&arr1(&vec![0.5, 0.0, -0.5, 0.0]), 1e-6));
-        assert!(f.project(&vec![0.5, 6.0]).all_close(&arr1(&vec![0.5, -0.5, 0.0, 0.0]), 1e-6));
-        assert!(f.project(&vec![1.0, 6.0]).all_close(&arr1(&vec![0.25, -0.25, -0.25, 0.25]), 1e-6));
+        assert!(f.project(&vec![0.0, 5.0]).all_close(&arr1(&vec![1.0/3.0; 3]), 1e-6));
+        assert!(f.project(&vec![0.5, 5.0]).all_close(&arr1(&vec![4.24042024e-17, 3.07486821e-1, 6.92513179e-1]), 1e-6));
+        assert!(f.project(&vec![0.0, 5.5]).all_close(&arr1(&vec![6.92513179e-1, 3.07486821e-1, 4.24042024e-17]), 1e-6));
+        assert!(f.project(&vec![0.5, 5.5]).all_close(&arr1(&vec![1.01093534e-16, -1.0, 1.01093534e-16]), 1e-6));
+        assert!(f.project(&vec![1.0, 5.5]).all_close(&arr1(&vec![-5.04567213e-1, -4.95432787e-1, 3.08958311e-17]), 1e-6));
+        assert!(f.project(&vec![0.5, 6.0]).all_close(&arr1(&vec![3.08958311e-17, -4.95432787e-1, -5.04567213e-1]), 1e-6));
+        assert!(f.project(&vec![1.0, 6.0]).all_close(&arr1(&vec![-0.44125654, -0.11748691, -0.44125654]), 1e-6));
     }
 
     #[test]
-    fn test_order2_1d() {
-        let f = Fourier::new(2, vec![(0.0, 1.0)]);
+    fn test_order2_2d() {
+        let f = Fourier::new(2, vec![(0.0, 1.0), (5.0, 6.0)]);
 
-        assert_eq!(f.dim(), 1);
-        assert_eq!(f.size(), 3);
+        assert_eq!(f.dim(), 2);
+        assert_eq!(f.size(), 5);
 
-        assert!(f.project(&vec![-1.0]).all_close(&arr1(&vec![1.0/3.0, -1.0/3.0, 1.0/3.0]), 1e-6));
-        assert!(f.project(&vec![-0.5]).all_close(&arr1(&vec![0.5, 0.0, -0.5]), 1e-6));
-        assert!(f.project(&vec![0.0]).all_close(&arr1(&vec![1.0/3.0, 1.0/3.0, 1.0/3.0]), 1e-6));
-        assert!(f.project(&vec![0.5]).all_close(&arr1(&vec![0.5, 0.0, -0.5]), 1e-6));
-        assert!(f.project(&vec![1.0]).all_close(&arr1(&vec![1.0/3.0, -1.0/3.0, 1.0/3.0]), 1e-6));
-
-
-        assert!(f.project(&vec![-2.0/3.0]).all_close(&arr1(&vec![0.5, -0.25, -0.25]), 1e-6));
-        assert!(f.project(&vec![-1.0/3.0]).all_close(&arr1(&vec![0.5, 0.25, -0.25]), 1e-6));
-        assert!(f.project(&vec![1.0/3.0]).all_close(&arr1(&vec![0.5, 0.25, -0.25]), 1e-6));
-        assert!(f.project(&vec![2.0/3.0]).all_close(&arr1(&vec![0.5, -0.25, -0.25]), 1e-6));
+        assert!(f.project(&vec![0.0, 5.0]).all_close(&arr1(&vec![0.2; 5]), 1e-6));
+        assert!(f.project(&vec![0.5, 5.0]).all_close(&arr1(&vec![2.58110397e-17, 6.95831686e-2,
+                                                                 1.87164340e-1, 3.21726225e-1,
+                                                                 4.21526267e-1]), 1e-6));
+        assert!(f.project(&vec![0.5, 5.5]).all_close(&arr1(&vec![3.76070090e-17, -3.13998939e-1,
+                                                                 -3.72002121e-1, -3.13998939e-1,
+                                                                 3.76070090e-17]), 1e-6));
+        assert!(f.project(&vec![0.5, 6.0]).all_close(&arr1(&vec![1.58656439e-17, -2.44984612e-1,
+                                                                 -2.54414913e-1, -2.41494847e-1,
+                                                                 -2.59105628e-1]), 1e-6));
+        assert!(f.project(&vec![1.0, 6.0]).all_close(&arr1(&vec![-0.31048999, -0.1481752,
+                                                                 -0.08266962, -0.1481752,
+                                                                 -0.31048999]), 1e-6));
     }
 }

--- a/src/fa/projection/rbf_network.rs
+++ b/src/fa/projection/rbf_network.rs
@@ -1,11 +1,12 @@
 use super::Projection;
 use geometry::{Span, Space, RegularSpace};
+use geometry::norms::l1;
 use geometry::dimensions::{Continuous, Partitioned};
 use ndarray::{Axis, ArrayView, Array1, Array2};
 use utils::cartesian_product;
 
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct RBFNetwork {
     mu: Array2<f64>,
     beta: Array1<f64>,
@@ -54,8 +55,9 @@ impl RBFNetwork {
 impl Projection<RegularSpace<Continuous>> for RBFNetwork {
     fn project_onto(&self, input: &Vec<f64>, phi: &mut Array1<f64>) {
         let p = self.kernel(input);
+        let z = l1(p.as_slice().unwrap());
 
-        phi.scaled_add(1.0/p.scalar_sum(), &p)
+        phi.scaled_add(1.0/z, &p);
     }
 
     fn dim(&self) -> usize {

--- a/src/fa/projection/tile_coding.rs
+++ b/src/fa/projection/tile_coding.rs
@@ -1,15 +1,17 @@
 use std::hash::{Hasher, BuildHasher};
 use super::{Projection, SparseProjection};
 use geometry::RegularSpace;
+use geometry::norms::l2;
 use geometry::dimensions::Continuous;
 use ndarray::Array1;
 
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct TileCoding<H: BuildHasher> {
     hasher_builder: H,
     n_tilings: usize,
     memory_size: usize,
+    activation: f64,
 }
 
 impl<H: BuildHasher> TileCoding<H> {
@@ -18,6 +20,7 @@ impl<H: BuildHasher> TileCoding<H> {
             hasher_builder: hasher_builder,
             n_tilings: n_tilings,
             memory_size: memory_size,
+            activation: 1.0/l2(&vec![1.0; n_tilings]),
         }
     }
 }
@@ -25,7 +28,7 @@ impl<H: BuildHasher> TileCoding<H> {
 impl<H: BuildHasher> Projection<RegularSpace<Continuous>> for TileCoding<H> {
     fn project_onto(&self, input: &Vec<f64>, phi: &mut Array1<f64>) {
         for t in self.project_sparse(input).iter() {
-            phi[*t] = 1.0;
+            phi[*t] = self.activation;
         }
     }
 

--- a/src/fa/projection/tile_coding.rs
+++ b/src/fa/projection/tile_coding.rs
@@ -1,7 +1,7 @@
 use std::hash::{Hasher, BuildHasher};
 use super::{Projection, SparseProjection};
 use geometry::RegularSpace;
-use geometry::norms::l2;
+use geometry::norms::l1;
 use geometry::dimensions::Continuous;
 use ndarray::Array1;
 
@@ -20,7 +20,7 @@ impl<H: BuildHasher> TileCoding<H> {
             hasher_builder: hasher_builder,
             n_tilings: n_tilings,
             memory_size: memory_size,
-            activation: 1.0/l2(&vec![1.0; n_tilings]),
+            activation: 1.0/l1(&vec![1.0; n_tilings]),
         }
     }
 }

--- a/src/fa/projection/uniform_grid.rs
+++ b/src/fa/projection/uniform_grid.rs
@@ -59,9 +59,7 @@ mod tests {
 
     #[test]
     fn test_1d() {
-        let mut ds = RegularSpace::new();
-        ds = ds.push(Partitioned::new(0.0, 10.0, 10));
-
+        let ds = RegularSpace::new(vec![Partitioned::new(0.0, 10.0, 10)]);
         let t = UniformGrid::new(ds);
 
         assert_eq!(t.size(), 10);
@@ -78,10 +76,7 @@ mod tests {
 
     #[test]
     fn test_2d() {
-        let mut ds = RegularSpace::new();
-        ds = ds.push(Partitioned::new(0.0, 10.0, 10));
-        ds = ds.push(Partitioned::new(0.0, 10.0, 10));
-
+        let ds = RegularSpace::new(vec![Partitioned::new(0.0, 10.0, 10); 2]);
         let t = UniformGrid::new(ds);
 
         assert_eq!(t.size(), 100);
@@ -100,11 +95,7 @@ mod tests {
 
     #[test]
     fn test_3d() {
-        let mut ds = RegularSpace::new();
-        ds = ds.push(Partitioned::new(0.0, 10.0, 10));
-        ds = ds.push(Partitioned::new(0.0, 10.0, 10));
-        ds = ds.push(Partitioned::new(0.0, 10.0, 10));
-
+        let ds = RegularSpace::new(vec![Partitioned::new(0.0, 10.0, 10); 3]);
         let t = UniformGrid::new(ds);
 
         assert_eq!(t.size(), 1000);

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -1,3 +1,5 @@
+pub mod norms;
+
 mod span;
 pub use self::span::Span;
 

--- a/src/geometry/norms.rs
+++ b/src/geometry/norms.rs
@@ -1,0 +1,27 @@
+#[inline]
+pub fn l1(x: &[f64]) -> f64 {
+    x.iter().fold(0.0, |acc, v| acc + v.abs())
+}
+
+#[inline]
+pub fn l2(x: &[f64]) -> f64 {
+    x.iter().fold(0.0, |acc, v| acc + (v*v).abs()).sqrt()
+}
+
+#[inline]
+pub fn lp(x: &[f64], p: u8) -> f64 {
+    x.iter().fold(0.0, |acc, v| acc + v.abs().powi(p as i32)).powf((p as f64).recip())
+}
+
+#[inline]
+pub fn linf(x: &[f64]) -> f64 {
+    x.iter().fold(0.0, |max, v| {
+        let av = v.abs();
+
+        if av > max {
+            av
+        } else {
+            max
+        }
+    })
+}

--- a/src/geometry/spaces.rs
+++ b/src/geometry/spaces.rs
@@ -111,7 +111,17 @@ pub struct RegularSpace<D: Dimension> {
 }
 
 impl<D: Dimension> RegularSpace<D> {
-    pub fn new() -> Self {
+    pub fn new(dimensions: Vec<D>) -> Self {
+        let mut s = Self::empty();
+
+        for d in dimensions {
+            s = s.push(d);
+        }
+
+        s
+    }
+
+    pub fn empty() -> Self {
         RegularSpace {
             dimensions: vec![],
             span: Span::Null,
@@ -164,7 +174,7 @@ impl<D: Dimension> Space for RegularSpace<D> {
 
 impl<D: Dimension> FromIterator<D> for RegularSpace<D> {
     fn from_iter<I: IntoIterator<Item = D>>(iter: I) -> Self {
-        let mut s = Self::new();
+        let mut s = Self::empty();
 
         for i in iter {
             s = s.push(i);

--- a/src/geometry/spaces.rs
+++ b/src/geometry/spaces.rs
@@ -255,8 +255,7 @@ mod tests {
 
     #[test]
     fn test_unitary_space() {
-        let d = Discrete::new(2);
-        let us = UnitarySpace::new(d);
+        let us = UnitarySpace::new(Discrete::new(2));
         let mut rng = thread_rng();
 
         let mut counts = arr1(&vec![0.0; 2]);
@@ -269,14 +268,12 @@ mod tests {
 
         assert!((counts/5000.0).all_close(&arr1(&vec![0.5; 2]), 1e-1));
         assert_eq!(us.dim(), 1);
-        assert_eq!(us.span(), d.span());
+        assert_eq!(us.span(), Span::Finite(2));
     }
 
     #[test]
     fn test_pair_space() {
-        let d1 = Discrete::new(2);
-        let d2 = Discrete::new(2);
-        let ps = PairSpace::new(d1, d2);
+        let ps = PairSpace::new(Discrete::new(2), Discrete::new(2));
 
         let mut rng = thread_rng();
 
@@ -296,6 +293,31 @@ mod tests {
         assert!((c2/5000.0).all_close(&arr1(&vec![0.5; 2]), 1e-1));
 
         assert_eq!(ps.dim(), 2);
-        assert_eq!(ps.span(), d1.span()*d2.span());
+        assert_eq!(ps.span(), Span::Finite(4));
+    }
+
+    #[test]
+    fn test_regular_space() {
+        let space = RegularSpace::new(vec![Discrete::new(2); 2]);
+
+        let mut rng = thread_rng();
+
+        let mut c1 = arr1(&vec![0.0; 2]);
+        let mut c2 = arr1(&vec![0.0; 2]);
+        for _ in 0..5000 {
+            let sample = space.sample(&mut rng);
+
+            c1[sample[0]] += 1.0;
+            c2[sample[1]] += 1.0;
+
+            assert!(sample[0] == 0 || sample[0] == 1);
+            assert!(sample[1] == 0 || sample[1] == 1);
+        }
+
+        assert!((c1/5000.0).all_close(&arr1(&vec![0.5; 2]), 1e-1));
+        assert!((c2/5000.0).all_close(&arr1(&vec![0.5; 2]), 1e-1));
+
+        assert_eq!(space.dim(), 2);
+        assert_eq!(space.span(), Span::Finite(4));
     }
 }

--- a/src/policies/epsilon_greedy.rs
+++ b/src/policies/epsilon_greedy.rs
@@ -62,15 +62,15 @@ mod tests {
 
         let mut n0: f64 = 0.0;
         let mut n1: f64 = 0.0;
-        for _ in 0..20000 {
+        for _ in 0..10000 {
             match p.sample(&qs) {
                 0 => n0 += 1.0,
                 _ => n1 += 1.0,
             }
         }
 
-        assert!((0.75 - n0 / 20000.0).abs() < 0.01);
-        assert!((0.25 - n1 / 20000.0).abs() < 0.01);
+        assert!((0.75 - n0 / 10000.0).abs() < 0.05);
+        assert!((0.25 - n1 / 10000.0).abs() < 0.05);
     }
 
     #[test]

--- a/src/policies/random.rs
+++ b/src/policies/random.rs
@@ -36,15 +36,15 @@ mod tests {
 
         let mut n0: f64 = 0.0;
         let mut n1: f64 = 0.0;
-        for _ in 0..20000 {
+        for _ in 0..10000 {
             match p.sample(&qs) {
                 0 => n0 += 1.0,
                 _ => n1 += 1.0,
             }
         }
 
-        assert!((0.50 - n0 / 20000.0).abs() < 0.01);
-        assert!((0.50 - n1 / 20000.0).abs() < 0.01);
+        assert!((0.50 - n0 / 10000.0).abs() < 0.05);
+        assert!((0.50 - n1 / 10000.0).abs() < 0.05);
     }
 
     #[test]


### PR DESCRIPTION
Thus far the projection structs each coded their own implementation of the various normalisation schemes such as l1 or l2 norm. With this PR we include a new `geometry::norms` module which includes some methods for computing normalisation constants.

In addition, the projection structs have been refactored to use these new methods and their tests updated accordingly.