### PR TITLE
Dense/sparse projection

### DIFF
--- a/src/agents/control/gtd.rs
+++ b/src/agents/control/gtd.rs
@@ -1,7 +1,7 @@
 use Parameter;
 use agents::ControlAgent;
 use domains::Transition;
-use fa::{Function, VFunction, QFunction, Projection, Linear};
+use fa::{Function, VFunction, QFunction, Projector, Projection, Linear};
 use geometry::{Space, ActionSpace};
 use policies::{Policy, Greedy};
 use std::marker::PhantomData;
@@ -11,7 +11,7 @@ use std::marker::PhantomData;
 ///
 /// Maei, Hamid R., et al. "Toward off-policy learning control with function approximation."
 /// Proceedings of the 27th International Conference on Machine Learning (ICML-10). 2010.
-pub struct GreedyGQ<S: Space, M: Projection<S>, P: Policy> {
+pub struct GreedyGQ<S: Space, M: Projector<S>, P: Policy> {
     pub q_func: Linear<S, M>,
     pub v_func: Linear<S, M>,
 
@@ -24,7 +24,7 @@ pub struct GreedyGQ<S: Space, M: Projection<S>, P: Policy> {
     phantom: PhantomData<S>,
 }
 
-impl<S: Space, M: Projection<S>, P: Policy> GreedyGQ<S, M, P> {
+impl<S: Space, M: Projector<S>, P: Policy> GreedyGQ<S, M, P> {
     pub fn new<T1, T2, T3>(q_func: Linear<S, M>,
                            v_func: Linear<S, M>,
                            policy: P,
@@ -51,7 +51,7 @@ impl<S: Space, M: Projection<S>, P: Policy> GreedyGQ<S, M, P> {
     }
 }
 
-impl<S: Space, M: Projection<S>, P: Policy> ControlAgent<S, ActionSpace> for GreedyGQ<S, M, P> {
+impl<S: Space, M: Projector<S>, P: Policy> ControlAgent<S, ActionSpace> for GreedyGQ<S, M, P> {
     fn pi(&mut self, s: &S::Repr) -> usize {
         self.evaluate_policy(&mut Greedy, s)
     }
@@ -72,18 +72,24 @@ impl<S: Space, M: Projection<S>, P: Policy> ControlAgent<S, ActionSpace> for Gre
         let a = t.action;
         let (s, ns) = (t.from.state(), t.to.state());
 
-        let phi_s = self.q_func.project(s);
-        let phi_ns = self.q_func.project(ns);
+        let phi_s = self.v_func.projector.project(s);
+        let phi_ns = self.v_func.projector.project(ns);
 
-        let td_error = t.reward +
-                       self.q_func.evaluate_action_phi(&(self.gamma.value()*&phi_ns - &phi_s), a);
-        let td_estimate: f64 = self.v_func.evaluate(s);
+        let nqs = QFunction::evaluate_phi(&self.q_func, &phi_ns);
+        let na = Greedy.sample(&nqs);
+
+        let td_estimate = VFunction::evaluate_phi(&mut self.v_func, &phi_s);
+        let td_error = t.reward + self.gamma.value()*self.q_func.evaluate_action_phi(&phi_ns, na) -
+            self.q_func.evaluate_action_phi(&phi_s, a);
+
+        let phi_s = self.v_func.projector.expand_projection(phi_s);
+        let phi_ns = self.v_func.projector.expand_projection(phi_ns);
 
         let update_q = td_error*&phi_s - self.gamma*td_estimate*phi_ns;
         let update_v = (td_error - td_estimate)*phi_s;
 
-        self.q_func.update_action_phi(&update_q, a, self.alpha.value());
-        VFunction::update_phi(&mut self.v_func, &update_v, self.alpha*self.beta);
+        VFunction::update_phi(&mut self.v_func, &Projection::Dense(update_v), self.alpha*self.beta);
+        self.q_func.update_action_phi(&Projection::Dense(update_q), a, self.alpha.value());
     }
 
     fn handle_terminal(&mut self, _: &S::Repr) {

--- a/src/agents/memory.rs
+++ b/src/agents/memory.rs
@@ -1,7 +1,6 @@
 use Parameter;
 use ndarray::Array1;
 
-
 pub enum Trace {
     Accumulating {
         lambda: Parameter,
@@ -62,19 +61,19 @@ mod tests {
             eligibility: arr1(&[0.0f64; 10]),
         };
 
-        assert_eq!(trace.get(), &arr1(&[0.0f64; 10]));
+        assert_eq!(trace.get(), arr1(&[0.0f64; 10]));
 
         trace.decay(1.0);
-        assert_eq!(trace.get(), &arr1(&[0.0f64; 10]));
+        assert_eq!(trace.get(), arr1(&[0.0f64; 10]));
 
         trace.update(&arr1(&[1.0f64; 10]));
-        assert_eq!(trace.get(), &arr1(&[1.0f64; 10]));
+        assert_eq!(trace.get(), arr1(&[1.0f64; 10]));
 
         trace.decay(1.0);
-        assert_eq!(trace.get(), &arr1(&[0.95f64; 10]));
+        assert_eq!(trace.get(), arr1(&[0.95f64; 10]));
 
         trace.update(&arr1(&[1.0f64; 10]));
-        assert_eq!(trace.get(), &arr1(&[1.95f64; 10]));
+        assert_eq!(trace.get(), arr1(&[1.95f64; 10]));
     }
 
     #[test]
@@ -84,18 +83,18 @@ mod tests {
             eligibility: arr1(&[0.0f64; 10]),
         };
 
-        assert_eq!(trace.get(), &arr1(&[0.0f64; 10]));
+        assert_eq!(trace.get(), arr1(&[0.0f64; 10]));
 
         trace.decay(1.0);
-        assert_eq!(trace.get(), &arr1(&[0.0f64; 10]));
+        assert_eq!(trace.get(), arr1(&[0.0f64; 10]));
 
         trace.update(&arr1(&[1.0f64; 10]));
-        assert_eq!(trace.get(), &arr1(&[1.0f64; 10]));
+        assert_eq!(trace.get(), arr1(&[1.0f64; 10]));
 
         trace.decay(1.0);
-        assert_eq!(trace.get(), &arr1(&[0.95f64; 10]));
+        assert_eq!(trace.get(), arr1(&[0.95f64; 10]));
 
         trace.update(&arr1(&[1.0f64; 10]));
-        assert_eq!(trace.get(), &arr1(&[1.0f64; 10]));
+        assert_eq!(trace.get(), arr1(&[1.0f64; 10]));
     }
 }

--- a/src/agents/memory.rs
+++ b/src/agents/memory.rs
@@ -18,11 +18,11 @@ pub enum Trace {
 }
 
 impl Trace {
-    pub fn get(&self) -> &Array1<f64> {
+    pub fn get(&self) -> Array1<f64> {
         match self {
             &Trace::Accumulating { ref eligibility, .. } |
             &Trace::Replacing { ref eligibility, .. } |
-            &Trace::Null { ref eligibility } => eligibility,
+            &Trace::Null { ref eligibility } => eligibility.clone(),
         }
     }
 

--- a/src/agents/prediction/gtd.rs
+++ b/src/agents/prediction/gtd.rs
@@ -1,10 +1,10 @@
 use Parameter;
 use agents::PredictionAgent;
-use fa::{VFunction, Projection, Linear};
+use fa::{VFunction, Projector, Projection, Linear};
 use geometry::Space;
 
 
-pub struct GTD2<S: Space, P: Projection<S>> {
+pub struct GTD2<S: Space, P: Projector<S>> {
     pub v_func: Linear<S, P>,
     pub a_func: Linear<S, P>,
 
@@ -13,7 +13,7 @@ pub struct GTD2<S: Space, P: Projection<S>> {
     pub gamma: Parameter,
 }
 
-impl<S: Space, P: Projection<S>> GTD2<S, P> {
+impl<S: Space, P: Projector<S>> GTD2<S, P> {
     pub fn new<T1, T2, T3>(v_func: Linear<S, P>,
                            a_func: Linear<S, P>,
                            alpha: T1,
@@ -24,7 +24,7 @@ impl<S: Space, P: Projection<S>> GTD2<S, P> {
               T2: Into<Parameter>,
               T3: Into<Parameter>
     {
-        if !v_func.equivalent(&a_func) {
+        if !v_func.projector.equivalent(&a_func.projector) {
             panic!("v_func and a_func must be equivalent function approximators.")
         }
 
@@ -40,19 +40,25 @@ impl<S: Space, P: Projection<S>> GTD2<S, P> {
 }
 
 impl<S: Space, V> PredictionAgent<S> for GTD2<S, V>
-    where V: VFunction<S> + Projection<S>
+    where V: VFunction<S> + Projector<S>
 {
     fn handle_transition(&mut self, s: &S::Repr, ns: &S::Repr, r: f64) -> Option<f64> {
-        let phi_s = self.v_func.project(s);
-        let phi_ns = self.v_func.project(ns);
+        let phi_s = self.v_func.projector.project(s);
+        let phi_ns = self.v_func.projector.project(ns);
 
         let td_error = r + self.gamma*self.v_func.evaluate_phi(&phi_ns) -
-                       self.v_func.evaluate_phi(&phi_s);
+            self.v_func.evaluate_phi(&phi_s);
         let td_estimate = self.a_func.evaluate_phi(&phi_s);
 
-        self.v_func.update_phi(&(&phi_s - &(self.gamma.value()*&phi_ns)),
-                               self.alpha*td_estimate);
         self.a_func.update_phi(&phi_s, self.beta*(td_error - td_estimate));
+
+        {
+            let phi_s = self.v_func.projector.expand_projection(phi_s);
+            let phi_ns = self.v_func.projector.expand_projection(phi_ns);
+            let update = &phi_s - &(self.gamma.value()*&phi_ns);
+
+            self.v_func.update_phi(&Projection::Dense(update), self.alpha*td_estimate);
+        }
 
         Some(td_error)
     }
@@ -65,7 +71,7 @@ impl<S: Space, V> PredictionAgent<S> for GTD2<S, V>
 }
 
 
-pub struct TDC<S: Space, P: Projection<S>> {
+pub struct TDC<S: Space, P: Projector<S>> {
     pub v_func: Linear<S, P>,
     pub a_func: Linear<S, P>,
 
@@ -74,7 +80,7 @@ pub struct TDC<S: Space, P: Projection<S>> {
     pub gamma: Parameter,
 }
 
-impl<S: Space, P: Projection<S>> TDC<S, P> {
+impl<S: Space, P: Projector<S>> TDC<S, P> {
     pub fn new<T1, T2, T3>(v_func: Linear<S, P>,
                            a_func: Linear<S, P>,
                            alpha: T1,
@@ -85,7 +91,7 @@ impl<S: Space, P: Projection<S>> TDC<S, P> {
               T2: Into<Parameter>,
               T3: Into<Parameter>
     {
-        if !v_func.equivalent(&a_func) {
+        if !v_func.projector.equivalent(&a_func.projector) {
             panic!("v_func and a_func must be equivalent function approximators.")
         }
 
@@ -101,20 +107,25 @@ impl<S: Space, P: Projection<S>> TDC<S, P> {
 }
 
 impl<S: Space, V> PredictionAgent<S> for TDC<S, V>
-    where V: VFunction<S> + Projection<S>
+    where V: VFunction<S> + Projector<S>
 {
     fn handle_transition(&mut self, s: &S::Repr, ns: &S::Repr, r: f64) -> Option<f64> {
-        let phi_s = self.v_func.project(s);
-        let phi_ns = self.v_func.project(ns);
+        let phi_s = self.v_func.projector.project(s);
+        let phi_ns = self.v_func.projector.project(ns);
 
         let td_error = r + self.gamma*self.v_func.evaluate_phi(&phi_ns) -
-                       self.v_func.evaluate_phi(&phi_s);
+            self.v_func.evaluate_phi(&phi_s);
         let td_estimate = self.a_func.evaluate_phi(&phi_s);
 
-        self.v_func
-            .update_phi(&(&(td_error*&phi_s) - &(self.gamma.value()*td_estimate*&phi_ns)),
-                        self.alpha.value());
         self.a_func.update_phi(&phi_s, self.beta*(td_error - td_estimate));
+
+        {
+            let phi_s = self.v_func.projector.expand_projection(phi_s);
+            let phi_ns = self.v_func.projector.expand_projection(phi_ns);
+            let update = &(td_error*&phi_s) - &(self.gamma.value()*td_estimate*&phi_ns);
+
+            self.v_func.update_phi(&Projection::Dense(update), self.alpha.value());
+        }
 
         Some(td_error)
     }

--- a/src/fa/linear.rs
+++ b/src/fa/linear.rs
@@ -1,19 +1,18 @@
-use super::{Function, Parameterised, VFunction, QFunction, Projection, SparseProjection};
+use super::{Function, Parameterised, VFunction, QFunction, Projector, Projection};
 use geometry::Space;
-use ndarray::{ArrayView, Array1, Array2};
+use ndarray::{ArrayView, Array2};
 use std::marker::PhantomData;
-use utils::dot;
 
 
 #[derive(Serialize, Deserialize)]
-pub struct DenseLinear<S: Space, P: Projection<S>> {
+pub struct Linear<S: Space, P: Projector<S>> {
     pub projector: P,
     pub weights: Array2<f64>,
 
     phantom: PhantomData<S>,
 }
 
-impl<S: Space, P: Projection<S>> DenseLinear<S, P> {
+impl<S: Space, P: Projector<S>> Linear<S, P> {
     pub fn new(projector: P, n_outputs: usize) -> Self {
         let n_features = projector.size();
 
@@ -26,7 +25,7 @@ impl<S: Space, P: Projection<S>> DenseLinear<S, P> {
     }
 }
 
-impl<S: Space, P: Projection<S>> Function<S::Repr, f64> for DenseLinear<S, P> {
+impl<S: Space, P: Projector<S>> Function<S::Repr, f64> for Linear<S, P> {
     fn evaluate(&self, input: &S::Repr) -> f64 {
         // Compute the feature vector phi:
         let phi = self.projector.project(input);
@@ -35,7 +34,7 @@ impl<S: Space, P: Projection<S>> Function<S::Repr, f64> for DenseLinear<S, P> {
     }
 }
 
-impl<S: Space, P: Projection<S>> Function<S::Repr, Vec<f64>> for DenseLinear<S, P> {
+impl<S: Space, P: Projector<S>> Function<S::Repr, Vec<f64>> for Linear<S, P> {
     fn evaluate(&self, input: &S::Repr) -> Vec<f64> {
         // Compute the feature vector phi:
         let phi = self.projector.project(input);
@@ -45,7 +44,7 @@ impl<S: Space, P: Projection<S>> Function<S::Repr, Vec<f64>> for DenseLinear<S, 
     }
 }
 
-impl<S: Space, P: Projection<S>> Parameterised<S::Repr, f64> for DenseLinear<S, P> {
+impl<S: Space, P: Projector<S>> Parameterised<S::Repr, f64> for Linear<S, P> {
     fn update(&mut self, input: &S::Repr, error: f64) {
         // Compute the feature vector phi:
         let phi = self.projector.project(input);
@@ -54,7 +53,7 @@ impl<S: Space, P: Projection<S>> Parameterised<S::Repr, f64> for DenseLinear<S, 
     }
 }
 
-impl<S: Space, P: Projection<S>> Parameterised<S::Repr, Vec<f64>> for DenseLinear<S, P> {
+impl<S: Space, P: Projector<S>> Parameterised<S::Repr, Vec<f64>> for Linear<S, P> {
     fn update(&mut self, input: &S::Repr, errors: Vec<f64>) {
         // Compute the feature vector phi:
         let phi = self.projector.project(input);
@@ -63,18 +62,17 @@ impl<S: Space, P: Projection<S>> Parameterised<S::Repr, Vec<f64>> for DenseLinea
     }
 }
 
-impl<S: Space, P: Projection<S>> VFunction<S> for DenseLinear<S, P> {
-    fn evaluate_phi(&self, phi: &Array1<f64>) -> f64 {
-        dot(self.weights.column(0).as_slice().unwrap(),
-            phi.as_slice().unwrap())
+impl<S: Space, P: Projector<S>> VFunction<S> for Linear<S, P> {
+    fn evaluate_phi(&self, phi: &Projection) -> f64 {
+        <Self as QFunction<S>>::evaluate_action_phi(self, phi, 0)
     }
 
-    fn update_phi(&mut self, phi: &Array1<f64>, error: f64) {
-        self.weights.column_mut(0).scaled_add(error, phi);
+    fn update_phi(&mut self, phi: &Projection, error: f64) {
+        <Self as QFunction<S>>::update_action_phi(self, phi, 0, error);
     }
 }
 
-impl<S: Space, P: Projection<S>> QFunction<S> for DenseLinear<S, P> {
+impl<S: Space, P: Projector<S>> QFunction<S> for Linear<S, P> {
     fn evaluate_action(&self, input: &S::Repr, action: usize) -> f64 {
         let phi = self.projector.project(input);
 
@@ -87,123 +85,62 @@ impl<S: Space, P: Projection<S>> QFunction<S> for DenseLinear<S, P> {
         self.update_action_phi(&phi, action, error);
     }
 
-    fn evaluate_phi(&self, phi: &Array1<f64>) -> Vec<f64> {
-        (self.weights.t().dot(phi)).into_raw_vec()
-    }
-
-    fn evaluate_action_phi(&self, phi: &Array1<f64>, action: usize) -> f64 {
-        self.weights.column(action).dot(phi)
-    }
-
-    fn update_phi(&mut self, phi: &Array1<f64>, errors: Vec<f64>) {
-        let phi_view = phi.view().into_shape((self.weights.rows(), 1)).unwrap();
-        let error_matrix = ArrayView::from_shape((1, self.weights.cols()), errors.as_slice())
-            .unwrap();
-
-        self.weights += &phi_view.dot(&error_matrix);
-    }
-
-    fn update_action_phi(&mut self, phi: &Array1<f64>, action: usize, error: f64) {
-        self.weights.column_mut(action).scaled_add(error, &phi);
-    }
-}
-
-impl<S: Space, P: Projection<S>> Projection<S> for DenseLinear<S, P> {
-    fn project(&self, input: &S::Repr) -> Array1<f64> {
-        self.projector.project(input)
-    }
-
-    fn project_onto(&self, input: &S::Repr, phi: &mut Array1<f64>) {
-        self.projector.project_onto(input, phi);
-    }
-
-    fn dim(&self) -> usize {
-        self.projector.dim()
-    }
-
-    fn size(&self) -> usize {
-        self.projector.size()
-    }
-
-    fn equivalent(&self, other: &Self) -> bool {
-        self.projector.equivalent(&other.projector)
-    }
-}
-
-
-#[derive(Serialize, Deserialize)]
-pub struct SparseLinear<S: Space, P: SparseProjection<S>> {
-    pub projector: P,
-    pub weights: Array2<f64>,
-
-    phantom: PhantomData<S>,
-}
-
-impl<S: Space, P: SparseProjection<S>> SparseLinear<S, P> {
-    pub fn new(projector: P, n_outputs: usize) -> Self {
-        let n_features = projector.size();
-
-        Self {
-            projector: projector,
-            weights: Array2::<f64>::zeros((n_features, n_outputs)),
-
-            phantom: PhantomData,
+    fn evaluate_phi(&self, phi: &Projection) -> Vec<f64> {
+        match phi {
+            &Projection::Dense(ref dense_phi) => (self.weights.t().dot(dense_phi)).into_raw_vec(),
+            &Projection::Sparse(ref sparse_phi) =>
+                (0..self.weights.cols()).map(|c| {
+                    sparse_phi.iter().fold(0.0, |acc, idx| acc + self.weights[(c, *idx)])
+                }).collect(),
         }
     }
-}
 
-impl<S: Space, P: SparseProjection<S>> Function<S::Repr, f64> for SparseLinear<S, P> {
-    fn evaluate(&self, input: &S::Repr) -> f64 {
-        self.projector.project_sparse(input).fold(0.0f64,
-                                                  |acc, i| acc + self.weights.column(0)[*i])
-    }
-}
+    fn evaluate_action_phi(&self, phi: &Projection, action: usize) -> f64 {
+        let col = self.weights.column(action);
 
-impl<S: Space, P: SparseProjection<S>> Function<S::Repr, Vec<f64>> for SparseLinear<S, P> {
-    fn evaluate(&self, input: &S::Repr) -> Vec<f64> {
-        let indices = self.projector.project_sparse(input);
-
-        (0..self.weights.cols()).map(|c| {
-            indices.fold(0.0f64, |acc, i| acc + self.weights.column(c)[*i])
-        }).collect()
-    }
-}
-
-impl<S: Space, P: SparseProjection<S>> Parameterised<S::Repr, f64> for SparseLinear<S, P> {
-    fn update(&mut self, input: &S::Repr, error: f64) {
-        let scaled_error = error / self.projector.sparsity() as f64;
-
-        for i in self.projector.project_sparse(input).iter() {
-            self.weights.column_mut(0)[*i] += scaled_error;
+        match phi {
+            &Projection::Dense(ref dense_phi) => col.dot(&(dense_phi/phi.z())),
+            &Projection::Sparse(ref sparse_phi) =>
+                sparse_phi.iter().fold(0.0, |acc, idx| acc + col[*idx]),
         }
     }
-}
 
-impl<S: Space, P: SparseProjection<S>> Parameterised<S::Repr, Vec<f64>> for SparseLinear<S, P> {
-    fn update(&mut self, input: &S::Repr, errors: Vec<f64>) {
-        for c in 0..self.weights.cols() {
-            let scaled_error = errors[c] / self.projector.sparsity() as f64;
+    fn update_phi(&mut self, phi: &Projection, errors: Vec<f64>) {
+        let z = phi.z();
+        let sf = 1.0/z;
 
-            for i in self.projector.project_sparse(input).iter() {
-                self.weights.column_mut(c)[*i] += scaled_error;
-            }
+        match phi {
+            &Projection::Dense(ref dense_phi) => {
+                let view = dense_phi.view().into_shape((self.weights.rows(), 1)).unwrap();
+                let error_matrix = ArrayView::from_shape((1, self.weights.cols()), errors.as_slice())
+                    .unwrap();
+
+                self.weights.scaled_add(sf, &view.dot(&error_matrix))
+            },
+            &Projection::Sparse(ref sparse_phi) => {
+                for c in 0..self.weights.cols() {
+                    let mut col = self.weights.column_mut(c);
+                    let error = errors[c];
+
+                    for idx in sparse_phi {
+                        col[*idx] += error
+                    }
+                }
+            },
         }
     }
-}
 
-impl<S: Space, P: SparseProjection<S>> VFunction<S> for SparseLinear<S, P> {}
+    fn update_action_phi(&mut self, phi: &Projection, action: usize, error: f64) {
+        let mut col = self.weights.column_mut(action);
+        let scaled_error = error/phi.z();
 
-impl<S: Space, P: SparseProjection<S>> QFunction<S> for SparseLinear<S, P> {
-    fn evaluate_action(&self, input: &S::Repr, action: usize) -> f64 {
-        self.projector.project_sparse(input).fold(0.0f64,
-                                                  |acc, i| acc + self.weights.column(action)[*i])
-    }
-
-    fn update_action(&mut self, input: &S::Repr, action: usize, error: f64) {
-        let scaled_error = error / self.projector.sparsity() as f64;
-
-        for i in self.projector.project_sparse(input).iter() {
-            self.weights.column_mut(action)[*i] += scaled_error;
+        match phi {
+            &Projection::Dense(ref dense_phi) => col.scaled_add(scaled_error, dense_phi),
+            &Projection::Sparse(ref sparse_phi) => {
+                for idx in sparse_phi {
+                    col[*idx] += scaled_error
+                }
+            },
         }
     }
 }
@@ -222,7 +159,7 @@ mod tests {
     #[test]
     fn test_dense_update_eval() {
         let p = TileCoding::new(SHBuilder::default(), 4, 100);
-        let mut f = DenseLinear::new(p.clone(), 1);
+        let mut f = Linear::new(p.clone(), 1);
 
         let input = vec![5.0];
 
@@ -235,7 +172,7 @@ mod tests {
     #[test]
     fn test_dense_eval_phi() {
         let p = TileCoding::new(SHBuilder::default(), 4, 100);
-        let f = DenseLinear::new(p.clone(), 1);
+        let f = Linear::new(p.clone(), 1);
 
         let input = vec![5.0];
 

--- a/src/fa/linear.rs
+++ b/src/fa/linear.rs
@@ -90,7 +90,7 @@ impl<S: Space, P: Projector<S>> QFunction<S> for Linear<S, P> {
             &Projection::Dense(ref dense_phi) => (self.weights.t().dot(dense_phi)).into_raw_vec(),
             &Projection::Sparse(ref sparse_phi) =>
                 (0..self.weights.cols()).map(|c| {
-                    sparse_phi.iter().fold(0.0, |acc, idx| acc + self.weights[(c, *idx)])
+                    sparse_phi.iter().fold(0.0, |acc, idx| acc + self.weights[(*idx, c)])
                 }).collect(),
         }
     }

--- a/src/fa/mod.rs
+++ b/src/fa/mod.rs
@@ -1,5 +1,4 @@
 use geometry::Space;
-use ndarray::Array1;
 
 /// An interface for dealing with functions that may be evaluated.
 pub trait Function<I: ?Sized, O> {
@@ -33,11 +32,11 @@ impl<I: ?Sized, E, T> Parameterised<I, E> for Box<T>
 /// An interface for value functions.
 pub trait VFunction<S: Space>
     : Function<S::Repr, f64> + Parameterised<S::Repr, f64> {
-    fn evaluate_phi(&self, _: &Array1<f64>) -> f64 {
+    fn evaluate_phi(&self, _: &Projection) -> f64 {
         unimplemented!()
     }
 
-    fn update_phi(&mut self, _: &Array1<f64>, _: f64) {
+    fn update_phi(&mut self, _: &Projection, _: f64) {
         unimplemented!()
     }
 }
@@ -45,11 +44,11 @@ pub trait VFunction<S: Space>
 impl<S: Space, T> VFunction<S> for Box<T>
     where T: VFunction<S>
 {
-    fn evaluate_phi(&self, phi: &Array1<f64>) -> f64 {
+    fn evaluate_phi(&self, phi: &Projection) -> f64 {
         (**self).evaluate_phi(phi)
     }
 
-    fn update_phi(&mut self, phi: &Array1<f64>, error: f64) {
+    fn update_phi(&mut self, phi: &Projection, error: f64) {
         (**self).update_phi(phi, error);
     }
 }
@@ -61,48 +60,21 @@ pub trait QFunction<S: Space>
     fn evaluate_action(&self, input: &S::Repr, action: usize) -> f64;
     fn update_action(&mut self, input: &S::Repr, action: usize, error: f64);
 
-    fn evaluate_phi(&self, _: &Array1<f64>) -> Vec<f64> {
+    fn evaluate_phi(&self, _: &Projection) -> Vec<f64> {
         unimplemented!();
     }
 
-    fn evaluate_action_phi(&self, _: &Array1<f64>, _: usize) -> f64 {
+    fn evaluate_action_phi(&self, _: &Projection, _: usize) -> f64 {
         unimplemented!();
     }
 
-    fn update_phi(&mut self, _: &Array1<f64>, _: Vec<f64>) {
+    fn update_phi(&mut self, _: &Projection, _: Vec<f64>) {
         unimplemented!();
     }
 
-    fn update_action_phi(&mut self, _: &Array1<f64>, _: usize, _: f64) {
+    fn update_action_phi(&mut self, _: &Projection, _: usize, _: f64) {
         unimplemented!();
     }
-
-    // NOTE: Eventually we may want to distinguish between the feature vector
-    //       for each action. I can't see this being needed anytime soon so
-    //       for now we will just have a single entry point for computing phi.
-    // fn phi(&self, input: &S::Repr) -> Array2<f64> {
-    // unimplemented!()
-    // }
-
-    // fn phi_action(&self, input: &S::Repr, _: usize) -> Array1<f64>{
-    // unimplemented!()
-    // }
-
-    // fn evaluate_phi(&self, phi: &Array2<f64>) -> f64 {
-    // unimplemented!();
-    // }
-
-    // fn evaluate_action_phi(&self, phi: &Array1<f64>, action: usize) -> f64 {
-    // unimplemented!();
-    // }
-
-    // fn update_phi(&mut self, phi: &Array2<f64>, error: f64) -> f64 {
-    // unimplemented!();
-    // }
-
-    // fn update_action_phi(&mut self, phi: &Array1<f64>, action: usize, error: f64) -> f64 {
-    // unimplemented!();
-    // }
 }
 
 impl<S: Space, T> QFunction<S> for Box<T>
@@ -116,19 +88,19 @@ impl<S: Space, T> QFunction<S> for Box<T>
         (**self).update_action(input, action, error);
     }
 
-    fn evaluate_phi(&self, phi: &Array1<f64>) -> Vec<f64> {
+    fn evaluate_phi(&self, phi: &Projection) -> Vec<f64> {
         (**self).evaluate_phi(phi)
     }
 
-    fn evaluate_action_phi(&self, phi: &Array1<f64>, action: usize) -> f64 {
+    fn evaluate_action_phi(&self, phi: &Projection, action: usize) -> f64 {
         (**self).evaluate_action_phi(phi, action)
     }
 
-    fn update_phi(&mut self, phi: &Array1<f64>, error: Vec<f64>) {
-        (**self).update_phi(phi, error);
+    fn update_phi(&mut self, phi: &Projection, errors: Vec<f64>) {
+        (**self).update_phi(phi, errors);
     }
 
-    fn update_action_phi(&mut self, phi: &Array1<f64>, action: usize, error: f64) {
+    fn update_action_phi(&mut self, phi: &Projection, action: usize, error: f64) {
         (**self).update_action_phi(phi, action, error)
     }
 }
@@ -138,9 +110,7 @@ mod table;
 pub use self::table::Table;
 
 pub mod projection;
-pub use self::projection::{Projection, SparseProjection};
+pub use self::projection::{Projector, Projection};
 
 mod linear;
-pub use self::linear::{DenseLinear, SparseLinear};
-
-pub type Linear<S, P> = DenseLinear<S, P>;
+pub use self::linear::Linear;

--- a/src/fa/projection/basis_network.rs
+++ b/src/fa/projection/basis_network.rs
@@ -1,4 +1,4 @@
-use super::Projection;
+use super::{Projector, Projection};
 use fa::Function;
 use geometry::RegularSpace;
 use geometry::dimensions::Continuous;
@@ -38,15 +38,11 @@ impl BasisNetwork {
     }
 }
 
-impl Projection<RegularSpace<Continuous>> for BasisNetwork {
-    fn project(&self, input: &Vec<f64>) -> Array1<f64> {
-        Array1::from_shape_fn((self.bases.len(),), |i| self.bases[i].evaluate(input))
-    }
+impl Projector<RegularSpace<Continuous>> for BasisNetwork {
+    fn project(&self, input: &Vec<f64>) -> Projection {
+        let phi = Array1::from_shape_fn((self.bases.len(),), |i| self.bases[i].evaluate(input));
 
-    fn project_onto(&self, input: &Vec<f64>, phi: &mut Array1<f64>) {
-        for i in 0..self.bases.len() {
-            phi[i] = self.bases[i].evaluate(input);
-        }
+        Projection::Dense(phi)
     }
 
     fn dim(&self) -> usize {
@@ -55,6 +51,10 @@ impl Projection<RegularSpace<Continuous>> for BasisNetwork {
 
     fn size(&self) -> usize {
         self.bases.len()
+    }
+
+    fn activation(&self) -> usize {
+        self.size()
     }
 
     fn equivalent(&self, _: &Self) -> bool {

--- a/src/fa/projection/fourier.rs
+++ b/src/fa/projection/fourier.rs
@@ -97,8 +97,8 @@ mod tests {
     fn test_symmetry() {
         let f = Fourier::new(1, vec![(0.0, 1.0)]);
 
-        assert_eq!(f.project(&vec![-1.0]), f.project(&vec![1.0]));
-        assert_eq!(f.project(&vec![-0.5]), f.project(&vec![0.5]));
+        assert_eq!(f.project_expanded(&vec![-1.0]), f.project_expanded(&vec![1.0]));
+        assert_eq!(f.project_expanded(&vec![-0.5]), f.project_expanded(&vec![0.5]));
     }
 
     #[test]
@@ -108,16 +108,16 @@ mod tests {
         assert_eq!(f.dim(), 1);
         assert_eq!(f.size(), 1);
 
-        assert!(f.project(&vec![-1.0]).all_close(&arr1(&vec![-1.0]), 1e-6));
-        assert!(f.project(&vec![-0.5]).all_close(&arr1(&vec![0.0]), 1e-6));
-        assert!(f.project(&vec![0.0]).all_close(&arr1(&vec![1.0]), 1e-6));
-        assert!(f.project(&vec![0.5]).all_close(&arr1(&vec![0.0]), 1e-6));
-        assert!(f.project(&vec![1.0]).all_close(&arr1(&vec![-1.0]), 1e-6));
+        assert!(f.project_expanded(&vec![-1.0]).all_close(&arr1(&vec![-1.0]), 1e-6));
+        assert!(f.project_expanded(&vec![-0.5]).all_close(&arr1(&vec![0.0]), 1e-6));
+        assert!(f.project_expanded(&vec![0.0]).all_close(&arr1(&vec![1.0]), 1e-6));
+        assert!(f.project_expanded(&vec![0.5]).all_close(&arr1(&vec![0.0]), 1e-6));
+        assert!(f.project_expanded(&vec![1.0]).all_close(&arr1(&vec![-1.0]), 1e-6));
 
-        assert!(f.project(&vec![-2.0/3.0]).all_close(&arr1(&vec![-1.0]), 1e-6));
-        assert!(f.project(&vec![-1.0/3.0]).all_close(&arr1(&vec![1.0]), 1e-6));
-        assert!(f.project(&vec![1.0/3.0]).all_close(&arr1(&vec![1.0]), 1e-6));
-        assert!(f.project(&vec![2.0/3.0]).all_close(&arr1(&vec![-1.0]), 1e-6));
+        assert!(f.project_expanded(&vec![-2.0/3.0]).all_close(&arr1(&vec![-1.0]), 1e-6));
+        assert!(f.project_expanded(&vec![-1.0/3.0]).all_close(&arr1(&vec![1.0]), 1e-6));
+        assert!(f.project_expanded(&vec![1.0/3.0]).all_close(&arr1(&vec![1.0]), 1e-6));
+        assert!(f.project_expanded(&vec![2.0/3.0]).all_close(&arr1(&vec![-1.0]), 1e-6));
     }
 
     #[test]
@@ -128,17 +128,17 @@ mod tests {
         assert_eq!(f2.dim(), f1.dim());
         assert_eq!(f2.size(), f2.size());
 
-        assert_eq!(f2.project(&vec![-1.0]), f1.project(&vec![-1.0]));
-        assert_eq!(f2.project(&vec![-0.5]), f1.project(&vec![-0.5]));
-        assert_eq!(f2.project(&vec![0.0]), f1.project(&vec![0.0]));
-        assert_eq!(f2.project(&vec![0.5]), f1.project(&vec![0.5]));
-        assert_eq!(f2.project(&vec![1.0]), f1.project(&vec![1.0]));
+        assert_eq!(f2.project_expanded(&vec![-1.0]), f1.project_expanded(&vec![-1.0]));
+        assert_eq!(f2.project_expanded(&vec![-0.5]), f1.project_expanded(&vec![-0.5]));
+        assert_eq!(f2.project_expanded(&vec![0.0]), f1.project_expanded(&vec![0.0]));
+        assert_eq!(f2.project_expanded(&vec![0.5]), f1.project_expanded(&vec![0.5]));
+        assert_eq!(f2.project_expanded(&vec![1.0]), f1.project_expanded(&vec![1.0]));
 
 
-        assert_eq!(f2.project(&vec![-2.0/3.0]), f1.project(&vec![-2.0/3.0]));
-        assert_eq!(f2.project(&vec![-1.0/3.0]), f1.project(&vec![-1.0/3.0]));
-        assert_eq!(f2.project(&vec![1.0/3.0]), f1.project(&vec![1.0/3.0]));
-        assert_eq!(f2.project(&vec![2.0/3.0]), f1.project(&vec![2.0/3.0]));
+        assert_eq!(f2.project_expanded(&vec![-2.0/3.0]), f1.project_expanded(&vec![-2.0/3.0]));
+        assert_eq!(f2.project_expanded(&vec![-1.0/3.0]), f1.project_expanded(&vec![-1.0/3.0]));
+        assert_eq!(f2.project_expanded(&vec![1.0/3.0]), f1.project_expanded(&vec![1.0/3.0]));
+        assert_eq!(f2.project_expanded(&vec![2.0/3.0]), f1.project_expanded(&vec![2.0/3.0]));
     }
 
     #[test]
@@ -148,13 +148,13 @@ mod tests {
         assert_eq!(f.dim(), 2);
         assert_eq!(f.size(), 3);
 
-        assert!(f.project(&vec![0.0, 5.0]).all_close(&arr1(&vec![1.0/3.0; 3]), 1e-6));
-        assert!(f.project(&vec![0.5, 5.0]).all_close(&arr1(&vec![4.24042024e-17, 3.07486821e-1, 6.92513179e-1]), 1e-6));
-        assert!(f.project(&vec![0.0, 5.5]).all_close(&arr1(&vec![6.92513179e-1, 3.07486821e-1, 4.24042024e-17]), 1e-6));
-        assert!(f.project(&vec![0.5, 5.5]).all_close(&arr1(&vec![1.01093534e-16, -1.0, 1.01093534e-16]), 1e-6));
-        assert!(f.project(&vec![1.0, 5.5]).all_close(&arr1(&vec![-5.04567213e-1, -4.95432787e-1, 3.08958311e-17]), 1e-6));
-        assert!(f.project(&vec![0.5, 6.0]).all_close(&arr1(&vec![3.08958311e-17, -4.95432787e-1, -5.04567213e-1]), 1e-6));
-        assert!(f.project(&vec![1.0, 6.0]).all_close(&arr1(&vec![-0.44125654, -0.11748691, -0.44125654]), 1e-6));
+        assert!(f.project_expanded(&vec![0.0, 5.0]).all_close(&arr1(&vec![1.0/3.0; 3]), 1e-6));
+        assert!(f.project_expanded(&vec![0.5, 5.0]).all_close(&arr1(&vec![4.24042024e-17, 3.07486821e-1, 6.92513179e-1]), 1e-6));
+        assert!(f.project_expanded(&vec![0.0, 5.5]).all_close(&arr1(&vec![6.92513179e-1, 3.07486821e-1, 4.24042024e-17]), 1e-6));
+        assert!(f.project_expanded(&vec![0.5, 5.5]).all_close(&arr1(&vec![1.01093534e-16, -1.0, 1.01093534e-16]), 1e-6));
+        assert!(f.project_expanded(&vec![1.0, 5.5]).all_close(&arr1(&vec![-5.04567213e-1, -4.95432787e-1, 3.08958311e-17]), 1e-6));
+        assert!(f.project_expanded(&vec![0.5, 6.0]).all_close(&arr1(&vec![3.08958311e-17, -4.95432787e-1, -5.04567213e-1]), 1e-6));
+        assert!(f.project_expanded(&vec![1.0, 6.0]).all_close(&arr1(&vec![-0.44125654, -0.11748691, -0.44125654]), 1e-6));
     }
 
     #[test]
@@ -164,17 +164,17 @@ mod tests {
         assert_eq!(f.dim(), 2);
         assert_eq!(f.size(), 5);
 
-        assert!(f.project(&vec![0.0, 5.0]).all_close(&arr1(&vec![0.2; 5]), 1e-6));
-        assert!(f.project(&vec![0.5, 5.0]).all_close(&arr1(&vec![2.58110397e-17, 6.95831686e-2,
+        assert!(f.project_expanded(&vec![0.0, 5.0]).all_close(&arr1(&vec![0.2; 5]), 1e-6));
+        assert!(f.project_expanded(&vec![0.5, 5.0]).all_close(&arr1(&vec![2.58110397e-17, 6.95831686e-2,
                                                                  1.87164340e-1, 3.21726225e-1,
                                                                  4.21526267e-1]), 1e-6));
-        assert!(f.project(&vec![0.5, 5.5]).all_close(&arr1(&vec![3.76070090e-17, -3.13998939e-1,
+        assert!(f.project_expanded(&vec![0.5, 5.5]).all_close(&arr1(&vec![3.76070090e-17, -3.13998939e-1,
                                                                  -3.72002121e-1, -3.13998939e-1,
                                                                  3.76070090e-17]), 1e-6));
-        assert!(f.project(&vec![0.5, 6.0]).all_close(&arr1(&vec![1.58656439e-17, -2.44984612e-1,
+        assert!(f.project_expanded(&vec![0.5, 6.0]).all_close(&arr1(&vec![1.58656439e-17, -2.44984612e-1,
                                                                  -2.54414913e-1, -2.41494847e-1,
                                                                  -2.59105628e-1]), 1e-6));
-        assert!(f.project(&vec![1.0, 6.0]).all_close(&arr1(&vec![-0.31048999, -0.1481752,
+        assert!(f.project_expanded(&vec![1.0, 6.0]).all_close(&arr1(&vec![-0.31048999, -0.1481752,
                                                                  -0.08266962, -0.1481752,
                                                                  -0.31048999]), 1e-6));
     }

--- a/src/fa/projection/mod.rs
+++ b/src/fa/projection/mod.rs
@@ -1,32 +1,63 @@
 use geometry::Space;
+use geometry::norms::l1;
 use ndarray::Array1;
 
 
-pub trait Projection<S: Space> {
-    fn project_onto(&self, input: &S::Repr, phi: &mut Array1<f64>);
-    fn project(&self, input: &S::Repr) -> Array1<f64> {
-        let mut phi = Array1::zeros((self.size(),));
-        self.project_onto(input, &mut phi);
+#[derive(Clone, Serialize, Deserialize)]
+pub enum Projection {
+    Dense(Array1<f64>),
+    Sparse(Array1<usize>),
+}
 
-        phi
+impl Projection {
+    pub fn z(&self) -> f64 {
+        match self {
+            &Projection::Dense(ref phi) => l1(phi.as_slice().unwrap()),
+            &Projection::Sparse(ref indices) => indices.len() as f64,
+        }
+    }
+}
+
+impl Into<Projection> for Array1<f64> {
+    fn into(self) -> Projection {
+        Projection::Dense(self)
+    }
+}
+
+impl Into<Projection> for Array1<usize> {
+    fn into(self) -> Projection {
+        Projection::Sparse(self)
+    }
+}
+
+
+pub trait Projector<S: Space> {
+    fn project(&self, input: &S::Repr) -> Projection;
+    fn project_expanded(&self, input: &S::Repr) -> Array1<f64> {
+        self.expand_projection(self.project(input))
     }
 
     fn dim(&self) -> usize;
     fn size(&self) -> usize;
+    fn activation(&self) -> usize;
     fn equivalent(&self, other: &Self) -> bool;
-}
 
-pub trait SparseProjection<S: Space>: Projection<S> {
-    fn project_onto_sparse(&self, input: &S::Repr, indices: &mut Array1<usize>);
-    fn project_sparse(&self, input: &S::Repr) -> Array1<usize> {
-        let mut indices: Array1<usize> = Array1::zeros((self.sparsity(),));
-        self.project_onto_sparse(input, &mut indices);
+    fn expand_projection(&self, projection: Projection) -> Array1<f64> {
+        match projection {
+            Projection::Dense(phi) => phi,
+            Projection::Sparse(sparse_phi) => {
+                let mut phi = Array1::zeros((self.size(),));
 
-        indices
+                for idx in sparse_phi.iter() {
+                    phi[*idx] = 1.0;
+                }
+
+                phi
+            },
+        }
     }
-
-    fn sparsity(&self) -> usize;
 }
+
 
 mod basis_network;
 pub use self::basis_network::*;

--- a/src/fa/projection/mod.rs
+++ b/src/fa/projection/mod.rs
@@ -43,8 +43,13 @@ pub trait Projector<S: Space> {
     fn equivalent(&self, other: &Self) -> bool;
 
     fn expand_projection(&self, projection: Projection) -> Array1<f64> {
+        let z = match projection.z() {
+            val if val.abs() < 1e-6 => 1.0,
+            val => val,
+        };
+
         match projection {
-            Projection::Dense(phi) => phi,
+            Projection::Dense(phi) => phi/z,
             Projection::Sparse(sparse_phi) => {
                 let mut phi = Array1::zeros((self.size(),));
 
@@ -52,7 +57,7 @@ pub trait Projector<S: Space> {
                     phi[*idx] = 1.0;
                 }
 
-                phi
+                phi/z
             },
         }
     }

--- a/src/fa/projection/rbf_network.rs
+++ b/src/fa/projection/rbf_network.rs
@@ -124,7 +124,7 @@ mod tests {
     #[test]
     fn test_projection_1d() {
         let rbf = RBFNetwork::new(arr2(&[[0.0], [0.5], [1.0]]), arr1(&[0.25]));
-        let phi = rbf.project(&vec![0.25]);
+        let phi = rbf.project_expanded(&vec![0.25]);
 
         assert!(phi.all_close(&arr1(&[0.49546264, 0.49546264, 0.00907471]), 1e-6));
         assert_eq!(phi.scalar_sum(), 1.0);
@@ -134,7 +134,7 @@ mod tests {
     fn test_projection_2d() {
         let rbf = RBFNetwork::new(arr2(&[[0.0, -10.0], [0.5, -8.0], [1.0, -6.0]]),
                                   arr1(&[0.25, 2.0]));
-        let phi = rbf.project(&vec![0.67, -7.0]);
+        let phi = rbf.project_expanded(&vec![0.67, -7.0]);
 
         assert!(phi.all_close(&arr1(&[0.10579518, 0.50344131, 0.3907635]), 1e-6));
         assert_eq!(phi.scalar_sum(), 1.0);

--- a/src/fa/projection/rbf_network.rs
+++ b/src/fa/projection/rbf_network.rs
@@ -1,6 +1,5 @@
-use super::Projection;
+use super::{Projector, Projection};
 use geometry::{Span, Space, RegularSpace};
-use geometry::norms::l1;
 use geometry::dimensions::{Continuous, Partitioned};
 use ndarray::{Axis, ArrayView, Array1, Array2};
 use utils::cartesian_product;
@@ -52,12 +51,9 @@ impl RBFNetwork {
     }
 }
 
-impl Projection<RegularSpace<Continuous>> for RBFNetwork {
-    fn project_onto(&self, input: &Vec<f64>, phi: &mut Array1<f64>) {
-        let p = self.kernel(input);
-        let z = l1(p.as_slice().unwrap());
-
-        phi.scaled_add(1.0/z, &p);
+impl Projector<RegularSpace<Continuous>> for RBFNetwork {
+    fn project(&self, input: &Vec<f64>) -> Projection {
+        Projection::Dense(self.kernel(input))
     }
 
     fn dim(&self) -> usize {
@@ -66,6 +62,10 @@ impl Projection<RegularSpace<Continuous>> for RBFNetwork {
 
     fn size(&self) -> usize {
         self.mu.rows()
+    }
+
+    fn activation(&self) -> usize {
+        self.size()
     }
 
     fn equivalent(&self, other: &Self) -> bool {

--- a/src/fa/projection/tile_coding.rs
+++ b/src/fa/projection/tile_coding.rs
@@ -1,7 +1,6 @@
 use std::hash::{Hasher, BuildHasher};
-use super::{Projection, SparseProjection};
+use super::{Projector, Projection};
 use geometry::RegularSpace;
-use geometry::norms::l1;
 use geometry::dimensions::Continuous;
 use ndarray::Array1;
 
@@ -11,7 +10,6 @@ pub struct TileCoding<H: BuildHasher> {
     hasher_builder: H,
     n_tilings: usize,
     memory_size: usize,
-    activation: f64,
 }
 
 impl<H: BuildHasher> TileCoding<H> {
@@ -20,16 +18,26 @@ impl<H: BuildHasher> TileCoding<H> {
             hasher_builder: hasher_builder,
             n_tilings: n_tilings,
             memory_size: memory_size,
-            activation: 1.0/l1(&vec![1.0; n_tilings]),
         }
     }
 }
 
-impl<H: BuildHasher> Projection<RegularSpace<Continuous>> for TileCoding<H> {
-    fn project_onto(&self, input: &Vec<f64>, phi: &mut Array1<f64>) {
-        for t in self.project_sparse(input).iter() {
-            phi[*t] = self.activation;
-        }
+impl<H: BuildHasher> Projector<RegularSpace<Continuous>> for TileCoding<H> {
+    fn project(&self, input: &Vec<f64>) -> Projection {
+        let mut hasher = self.hasher_builder.build_hasher();
+
+        let n_floats = input.len();
+        let floats: Vec<usize> =
+            input.iter().map(|f| (*f * self.n_tilings as f64).floor() as usize).collect();
+
+        Projection::Sparse(Array1::from_iter((0..self.n_tilings).map(|t| {
+            hasher.write_usize(t);
+            for i in 0..n_floats {
+                hasher.write_usize((floats[i] + t + i*t*2)/self.n_tilings)
+            }
+
+            hasher.finish() as usize % self.memory_size
+        })))
     }
 
     fn dim(&self) -> usize {
@@ -40,31 +48,12 @@ impl<H: BuildHasher> Projection<RegularSpace<Continuous>> for TileCoding<H> {
         self.memory_size as usize
     }
 
+    fn activation(&self) -> usize {
+        self.n_tilings
+    }
+
     fn equivalent(&self, other: &Self) -> bool {
         self.size() == other.size() && self.n_tilings == other.n_tilings &&
         self.memory_size == other.memory_size
-    }
-}
-
-impl<H: BuildHasher> SparseProjection<RegularSpace<Continuous>> for TileCoding<H> {
-    fn project_onto_sparse(&self, input: &Vec<f64>, indices: &mut Array1<usize>) {
-        let mut hasher = self.hasher_builder.build_hasher();
-
-        let n_floats = input.len();
-        let floats: Vec<usize> =
-            input.iter().map(|f| (*f * self.n_tilings as f64).floor() as usize).collect();
-
-        for t in 0..self.n_tilings {
-            hasher.write_usize(t);
-            for i in 0..n_floats {
-                hasher.write_usize((floats[i] + t + i*t*2) / self.n_tilings)
-            }
-
-            indices[t] = hasher.finish() as usize % self.memory_size;
-        }
-    }
-
-    fn sparsity(&self) -> usize {
-        self.n_tilings
     }
 }

--- a/src/fa/projection/uniform_grid.rs
+++ b/src/fa/projection/uniform_grid.rs
@@ -1,4 +1,4 @@
-use super::Projection;
+use super::{Projector, Projection};
 use geometry::{Space, RegularSpace};
 use geometry::dimensions::{Dimension, Continuous, Partitioned};
 use ndarray::Array1;
@@ -31,9 +31,9 @@ impl UniformGrid {
     }
 }
 
-impl Projection<RegularSpace<Continuous>> for UniformGrid {
-    fn project_onto(&self, input: &Vec<f64>, phi: &mut Array1<f64>) {
-        phi[self.hash(input)] = 1.0;
+impl Projector<RegularSpace<Continuous>> for UniformGrid {
+    fn project(&self, input: &Vec<f64>) -> Projection {
+        Projection::Sparse(Array1::from_vec(vec![self.hash(input)]))
     }
 
     fn dim(&self) -> usize {
@@ -44,6 +44,10 @@ impl Projection<RegularSpace<Continuous>> for UniformGrid {
         self.n_features
     }
 
+    fn activation(&self) -> usize {
+        1
+    }
+
     fn equivalent(&self, other: &Self) -> bool {
         self.dim() == other.dim() && self.size() == other.size()
     }
@@ -52,7 +56,7 @@ impl Projection<RegularSpace<Continuous>> for UniformGrid {
 
 #[cfg(test)]
 mod tests {
-    use super::{Projection, UniformGrid};
+    use super::{Projector, UniformGrid};
     use geometry::RegularSpace;
     use geometry::dimensions::Partitioned;
 


### PR DESCRIPTION
This PR includes breaking changes to the `fa` and `agents` modules which enable explicit handling of sparse and dense feature vectors derived from a `Projector` instance. These allow a developer to write optimised code for the sparse/dense case and/or force the `Projection` into an expanded (dense) vector.