### PR TITLE
Decouple code from Space::Repr

### DIFF
--- a/src/agents/control/mod.rs
+++ b/src/agents/control/mod.rs
@@ -2,18 +2,17 @@
 
 use super::Agent;
 use domains::Transition;
-use geometry::Space;
 use policies::Policy;
 
-pub trait Controller<S: Space, A: Space>: Agent<Sample = Transition<S, A>> {
+pub trait Controller<S, A>: Agent<Sample = Transition<S, A>> {
     /// Sample the target policy for a given state `s`.
-    fn pi(&mut self, s: &S::Repr) -> usize;
+    fn pi(&mut self, s: &S) -> usize;
 
     /// Sample the behaviour policy for a given state `s`.
-    fn mu(&mut self, s: &S::Repr) -> usize;
+    fn mu(&mut self, s: &S) -> usize;
 
     /// Sample a given policy against some state `s` for this agent.
-    fn evaluate_policy<T: Policy>(&self, p: &mut T, s: &S::Repr) -> usize;
+    fn evaluate_policy<T: Policy>(&self, p: &mut T, s: &S) -> usize;
 }
 
 pub mod td;

--- a/src/agents/control/totd.rs
+++ b/src/agents/control/totd.rs
@@ -13,11 +13,11 @@ use std::marker::PhantomData;
 /// - [Van Seijen, H., Mahmood, A. R., Pilarski, P. M., Machado, M. C., & Sutton, R. S. (2016).
 /// True online temporal-difference learning. Journal of Machine Learning Research, 17(145),
 /// 1-40.](https://arxiv.org/pdf/1512.04087.pdf)
-pub struct TOQLambda<S: Space, M: Projector<S::Repr>, P: Policy> {
+pub struct TOQLambda<S, M: Projector<S>, P: Policy> {
     trace: Trace,
     q_old: f64,
 
-    pub q_func: MultiLinear<S::Repr, M>,
+    pub q_func: MultiLinear<S, M>,
     pub policy: P,
 
     pub alpha: Parameter,
@@ -26,14 +26,14 @@ pub struct TOQLambda<S: Space, M: Projector<S::Repr>, P: Policy> {
     phantom: PhantomData<S>,
 }
 
-impl<S: Space, M, P> TOQLambda<S, M, P>
+impl<S, M, P> TOQLambda<S, M, P>
 where
-    M: Projector<S::Repr>,
+    M: Projector<S>,
     P: Policy,
 {
     pub fn new<T1, T2>(
         trace: Trace,
-        q_func: MultiLinear<S::Repr, M>,
+        q_func: MultiLinear<S, M>,
         policy: P,
         alpha: T1,
         gamma: T2,
@@ -57,26 +57,26 @@ where
     }
 }
 
-impl<S: Space, M: Projector<S::Repr>, P: Policy> Controller<S, ActionSpace> for TOQLambda<S, M, P> {
-    fn pi(&mut self, s: &S::Repr) -> usize {
+impl<S, M: Projector<S>, P: Policy> Controller<S, <ActionSpace as Space>::Repr> for TOQLambda<S, M, P> {
+    fn pi(&mut self, s: &S) -> usize {
         let qs: Vector<f64> = self.q_func.evaluate(s).unwrap();
 
         self.policy.sample(qs.as_slice().unwrap())
     }
 
-    fn mu(&mut self, s: &S::Repr) -> usize { self.pi(s) }
+    fn mu(&mut self, s: &S) -> usize { self.pi(s) }
 
-    fn evaluate_policy<T: Policy>(&self, p: &mut T, s: &S::Repr) -> usize {
+    fn evaluate_policy<T: Policy>(&self, p: &mut T, s: &S) -> usize {
         let qs: Vector<f64> = self.q_func.evaluate(s).unwrap();
 
         p.sample(qs.as_slice().unwrap())
     }
 }
 
-impl<S: Space, M: Projector<S::Repr>, P: Policy> Agent for TOQLambda<S, M, P> {
-    type Sample = Transition<S, ActionSpace>;
+impl<S, M: Projector<S>, P: Policy> Agent for TOQLambda<S, M, P> {
+    type Sample = Transition<S, <ActionSpace as Space>::Repr>;
 
-    fn handle_sample(&mut self, t: &Transition<S, ActionSpace>) {
+    fn handle_sample(&mut self, t: &Transition<S, <ActionSpace as Space>::Repr>) {
         let a = t.action;
         let (s, ns) = (t.from.state(), t.to.state());
 
@@ -131,11 +131,11 @@ impl<S: Space, M: Projector<S::Repr>, P: Policy> Agent for TOQLambda<S, M, P> {
 /// - [Van Seijen, H., Mahmood, A. R., Pilarski, P. M., Machado, M. C., & Sutton, R. S. (2016).
 /// True online temporal-difference learning. Journal of Machine Learning Research, 17(145),
 /// 1-40.](https://arxiv.org/pdf/1512.04087.pdf)
-pub struct TOSARSALambda<S: Space, M: Projector<S::Repr>, P: Policy> {
+pub struct TOSARSALambda<S, M: Projector<S>, P: Policy> {
     trace: Trace,
     q_old: f64,
 
-    pub q_func: MultiLinear<S::Repr, M>,
+    pub q_func: MultiLinear<S, M>,
     pub policy: P,
 
     pub alpha: Parameter,
@@ -144,14 +144,14 @@ pub struct TOSARSALambda<S: Space, M: Projector<S::Repr>, P: Policy> {
     phantom: PhantomData<S>,
 }
 
-impl<S: Space, M, P> TOSARSALambda<S, M, P>
+impl<S, M, P> TOSARSALambda<S, M, P>
 where
-    M: Projector<S::Repr>,
+    M: Projector<S>,
     P: Policy,
 {
     pub fn new<T1, T2>(
         trace: Trace,
-        q_func: MultiLinear<S::Repr, M>,
+        q_func: MultiLinear<S, M>,
         policy: P,
         alpha: T1,
         gamma: T2,
@@ -175,28 +175,28 @@ where
     }
 }
 
-impl<S: Space, M: Projector<S::Repr>, P: Policy> Controller<S, ActionSpace>
+impl<S, M: Projector<S>, P: Policy> Controller<S, <ActionSpace as Space>::Repr>
     for TOSARSALambda<S, M, P>
 {
-    fn pi(&mut self, s: &S::Repr) -> usize {
+    fn pi(&mut self, s: &S) -> usize {
         let qs: Vector<f64> = self.q_func.evaluate(s).unwrap();
 
         self.policy.sample(qs.as_slice().unwrap())
     }
 
-    fn mu(&mut self, s: &S::Repr) -> usize { self.pi(s) }
+    fn mu(&mut self, s: &S) -> usize { self.pi(s) }
 
-    fn evaluate_policy<T: Policy>(&self, p: &mut T, s: &S::Repr) -> usize {
+    fn evaluate_policy<T: Policy>(&self, p: &mut T, s: &S) -> usize {
         let qs: Vector<f64> = self.q_func.evaluate(s).unwrap();
 
         p.sample(qs.as_slice().unwrap())
     }
 }
 
-impl<S: Space, M: Projector<S::Repr>, P: Policy> Agent for TOSARSALambda<S, M, P> {
-    type Sample = Transition<S, ActionSpace>;
+impl<S, M: Projector<S>, P: Policy> Agent for TOSARSALambda<S, M, P> {
+    type Sample = Transition<S, <ActionSpace as Space>::Repr>;
 
-    fn handle_sample(&mut self, t: &Transition<S, ActionSpace>) {
+    fn handle_sample(&mut self, t: &Transition<S, <ActionSpace as Space>::Repr>) {
         let a = t.action;
         let (s, ns) = (t.from.state(), t.to.state());
 

--- a/src/agents/prediction/gtd.rs
+++ b/src/agents/prediction/gtd.rs
@@ -1,23 +1,22 @@
 use Parameter;
 use agents::{Agent, Predictor, TDPredictor};
 use fa::{Approximator, Projection, Projector, SimpleLinear, VFunction};
-use geometry::Space;
 
 // TODO: Implement TDPredictor for all agents here.
 
-pub struct GTD2<S: Space, P: Projector<S::Repr>> {
-    pub fa_theta: SimpleLinear<S::Repr, P>,
-    pub fa_w: SimpleLinear<S::Repr, P>,
+pub struct GTD2<S: ?Sized, P: Projector<S>> {
+    pub fa_theta: SimpleLinear<S, P>,
+    pub fa_w: SimpleLinear<S, P>,
 
     pub alpha: Parameter,
     pub beta: Parameter,
     pub gamma: Parameter,
 }
 
-impl<S: Space, P: Projector<S::Repr>> GTD2<S, P> {
+impl<S: ?Sized, P: Projector<S>> GTD2<S, P> {
     pub fn new<T1, T2, T3>(
-        fa_theta: SimpleLinear<S::Repr, P>,
-        fa_w: SimpleLinear<S::Repr, P>,
+        fa_theta: SimpleLinear<S, P>,
+        fa_w: SimpleLinear<S, P>,
         alpha: T1,
         beta: T2,
         gamma: T3,
@@ -42,8 +41,8 @@ impl<S: Space, P: Projector<S::Repr>> GTD2<S, P> {
     }
 }
 
-impl<S: Space, P: Projector<S::Repr>> Agent for GTD2<S, P> {
-    type Sample = (S::Repr, S::Repr, f64);
+impl<S: Sized, P: Projector<S>> Agent for GTD2<S, P> {
+    type Sample = (S, S, f64);
 
     fn handle_sample(&mut self, sample: &Self::Sample) {
         let phi_s = self.fa_theta.projector.project(&sample.0);
@@ -69,23 +68,24 @@ impl<S: Space, P: Projector<S::Repr>> Agent for GTD2<S, P> {
     }
 }
 
-impl<S: Space, P: Projector<S::Repr>> Predictor<S> for GTD2<S, P> {
-    fn evaluate(&self, s: &S::Repr) -> f64 { self.fa_theta.evaluate(s).unwrap() }
+impl<S: Sized, P: Projector<S>> Predictor<S> for GTD2<S, P> {
+    fn evaluate(&self, s: &S) -> f64 { self.fa_theta.evaluate(s).unwrap() }
 }
 
-pub struct TDC<S: Space, P: Projector<S::Repr>> {
-    pub fa_theta: SimpleLinear<S::Repr, P>,
-    pub fa_w: SimpleLinear<S::Repr, P>,
+
+pub struct TDC<S: ?Sized, P: Projector<S>> {
+    pub fa_theta: SimpleLinear<S, P>,
+    pub fa_w: SimpleLinear<S, P>,
 
     pub alpha: Parameter,
     pub beta: Parameter,
     pub gamma: Parameter,
 }
 
-impl<S: Space, P: Projector<S::Repr>> TDC<S, P> {
+impl<S: ?Sized, P: Projector<S>> TDC<S, P> {
     pub fn new<T1, T2, T3>(
-        fa_theta: SimpleLinear<S::Repr, P>,
-        fa_w: SimpleLinear<S::Repr, P>,
+        fa_theta: SimpleLinear<S, P>,
+        fa_w: SimpleLinear<S, P>,
         alpha: T1,
         beta: T2,
         gamma: T3,
@@ -110,8 +110,8 @@ impl<S: Space, P: Projector<S::Repr>> TDC<S, P> {
     }
 }
 
-impl<S: Space, P: Projector<S::Repr>> Agent for TDC<S, P> {
-    type Sample = (S::Repr, S::Repr, f64);
+impl<S: Sized, P: Projector<S>> Agent for TDC<S, P> {
+    type Sample = (S, S, f64);
 
     fn handle_sample(&mut self, sample: &Self::Sample) {
         let phi_s = self.fa_theta.projector.project(&sample.0);
@@ -138,8 +138,8 @@ impl<S: Space, P: Projector<S::Repr>> Agent for TDC<S, P> {
     }
 }
 
-impl<S: Space, P: Projector<S::Repr>> Predictor<S> for TDC<S, P> {
-    fn evaluate(&self, s: &S::Repr) -> f64 { self.fa_theta.evaluate(s).unwrap() }
+impl<S: Sized, P: Projector<S>> Predictor<S> for TDC<S, P> {
+    fn evaluate(&self, s: &S) -> f64 { self.fa_theta.evaluate(s).unwrap() }
 }
 
 // TODO:

--- a/src/agents/prediction/gtd.rs
+++ b/src/agents/prediction/gtd.rs
@@ -41,7 +41,7 @@ impl<S: ?Sized, P: Projector<S>> GTD2<S, P> {
     }
 }
 
-impl<S: Sized, P: Projector<S>> Agent for GTD2<S, P> {
+impl<S, P: Projector<S>> Agent for GTD2<S, P> {
     type Sample = (S, S, f64);
 
     fn handle_sample(&mut self, sample: &Self::Sample) {
@@ -68,7 +68,7 @@ impl<S: Sized, P: Projector<S>> Agent for GTD2<S, P> {
     }
 }
 
-impl<S: Sized, P: Projector<S>> Predictor<S> for GTD2<S, P> {
+impl<S, P: Projector<S>> Predictor<S> for GTD2<S, P> {
     fn evaluate(&self, s: &S) -> f64 { self.fa_theta.evaluate(s).unwrap() }
 }
 
@@ -110,7 +110,7 @@ impl<S: ?Sized, P: Projector<S>> TDC<S, P> {
     }
 }
 
-impl<S: Sized, P: Projector<S>> Agent for TDC<S, P> {
+impl<S, P: Projector<S>> Agent for TDC<S, P> {
     type Sample = (S, S, f64);
 
     fn handle_sample(&mut self, sample: &Self::Sample) {
@@ -138,7 +138,7 @@ impl<S: Sized, P: Projector<S>> Agent for TDC<S, P> {
     }
 }
 
-impl<S: Sized, P: Projector<S>> Predictor<S> for TDC<S, P> {
+impl<S, P: Projector<S>> Predictor<S> for TDC<S, P> {
     fn evaluate(&self, s: &S) -> f64 { self.fa_theta.evaluate(s).unwrap() }
 }
 

--- a/src/agents/prediction/mc.rs
+++ b/src/agents/prediction/mc.rs
@@ -4,7 +4,7 @@ use fa::VFunction;
 use std::marker::PhantomData;
 
 
-pub struct EveryVisitMC<S: Sized, V: VFunction<S>> {
+pub struct EveryVisitMC<S, V: VFunction<S>> {
     pub v_func: V,
     observations: Vec<(S, f64)>,
 
@@ -14,7 +14,7 @@ pub struct EveryVisitMC<S: Sized, V: VFunction<S>> {
     phantom: PhantomData<S>,
 }
 
-impl<S: Sized, V: VFunction<S>> EveryVisitMC<S, V> {
+impl<S, V: VFunction<S>> EveryVisitMC<S, V> {
     pub fn new<T1, T2>(v_func: V, alpha: T1, gamma: T2) -> Self
     where
         T1: Into<Parameter>,

--- a/src/agents/prediction/mc.rs
+++ b/src/agents/prediction/mc.rs
@@ -1,12 +1,12 @@
 use Parameter;
 use agents::{Agent, Predictor};
 use fa::VFunction;
-use geometry::Space;
 use std::marker::PhantomData;
 
-pub struct EveryVisitMC<S: Space, V: VFunction<S::Repr>> {
+
+pub struct EveryVisitMC<S: Sized, V: VFunction<S>> {
     pub v_func: V,
-    observations: Vec<(S::Repr, f64)>,
+    observations: Vec<(S, f64)>,
 
     pub alpha: Parameter,
     pub gamma: Parameter,
@@ -14,7 +14,7 @@ pub struct EveryVisitMC<S: Space, V: VFunction<S::Repr>> {
     phantom: PhantomData<S>,
 }
 
-impl<S: Space, V: VFunction<S::Repr>> EveryVisitMC<S, V> {
+impl<S: Sized, V: VFunction<S>> EveryVisitMC<S, V> {
     pub fn new<T1, T2>(v_func: V, alpha: T1, gamma: T2) -> Self
     where
         T1: Into<Parameter>,
@@ -43,8 +43,8 @@ impl<S: Space, V: VFunction<S::Repr>> EveryVisitMC<S, V> {
     }
 }
 
-impl<S: Space, V: VFunction<S::Repr>> Agent for EveryVisitMC<S, V> {
-    type Sample = (S::Repr, S::Repr, f64);
+impl<S: Clone, V: VFunction<S>> Agent for EveryVisitMC<S, V> {
+    type Sample = (S, S, f64);
 
     fn handle_sample(&mut self, sample: &Self::Sample) {
         self.observations.push((sample.0.clone(), sample.2.clone()));
@@ -58,6 +58,6 @@ impl<S: Space, V: VFunction<S::Repr>> Agent for EveryVisitMC<S, V> {
     }
 }
 
-impl<S: Space, V: VFunction<S::Repr>> Predictor<S> for EveryVisitMC<S, V> {
-    fn evaluate(&self, s: &S::Repr) -> f64 { self.v_func.evaluate(s).unwrap() }
+impl<S: Clone, V: VFunction<S>> Predictor<S> for EveryVisitMC<S, V> {
+    fn evaluate(&self, s: &S) -> f64 { self.v_func.evaluate(s).unwrap() }
 }

--- a/src/agents/prediction/mod.rs
+++ b/src/agents/prediction/mod.rs
@@ -1,13 +1,12 @@
 //! Prediction agents module.
 
 use super::Agent;
-use geometry::Space;
 
-pub trait Predictor<S: Space>: Agent<Sample = (S::Repr, S::Repr, f64)> {
-    fn evaluate(&self, s: &S::Repr) -> f64;
+pub trait Predictor<S: Sized>: Agent<Sample = (S, S, f64)> {
+    fn evaluate(&self, s: &S) -> f64;
 }
 
-pub trait TDPredictor<S: Space>: Predictor<S> {
+pub trait TDPredictor<S: Sized>: Predictor<S> {
     fn handle_td_error(&mut self, sample: &Self::Sample, td_error: f64);
     fn compute_td_error(&self, sample: &Self::Sample) -> f64;
 }

--- a/src/agents/prediction/td.rs
+++ b/src/agents/prediction/td.rs
@@ -30,7 +30,7 @@ impl<S: ?Sized, V: VFunction<S>> TD<S, V> {
     }
 }
 
-impl<S: Sized, V: VFunction<S>> Agent for TD<S, V> {
+impl<S, V: VFunction<S>> Agent for TD<S, V> {
     type Sample = (S, S, f64);
 
     fn handle_sample(&mut self, sample: &Self::Sample) {
@@ -45,11 +45,11 @@ impl<S: Sized, V: VFunction<S>> Agent for TD<S, V> {
     }
 }
 
-impl<S: Sized, V: VFunction<S>> Predictor<S> for TD<S, V> {
+impl<S, V: VFunction<S>> Predictor<S> for TD<S, V> {
     fn evaluate(&self, s: &S) -> f64 { self.v_func.evaluate(s).unwrap() }
 }
 
-impl<S: Sized, V: VFunction<S>> TDPredictor<S> for TD<S, V> {
+impl<S, V: VFunction<S>> TDPredictor<S> for TD<S, V> {
     fn handle_td_error(&mut self, sample: &Self::Sample, error: f64) {
         let _ = self.v_func.update(&sample.0, self.alpha * error);
     }
@@ -111,7 +111,7 @@ impl<S: ?Sized, P: Projector<S>> TDLambda<S, P> {
     }
 }
 
-impl<S: Sized, P: Projector<S>> Agent for TDLambda<S, P> {
+impl<S, P: Projector<S>> Agent for TDLambda<S, P> {
     type Sample = (S, S, f64);
 
     fn handle_sample(&mut self, sample: &Self::Sample) {
@@ -131,11 +131,11 @@ impl<S: Sized, P: Projector<S>> Agent for TDLambda<S, P> {
     }
 }
 
-impl<S: Sized, P: Projector<S>> Predictor<S> for TDLambda<S, P> {
+impl<S, P: Projector<S>> Predictor<S> for TDLambda<S, P> {
     fn evaluate(&self, s: &S) -> f64 { self.fa_theta.evaluate(s).unwrap() }
 }
 
-impl<S: Sized, P: Projector<S>> TDPredictor<S> for TDLambda<S, P> {
+impl<S, P: Projector<S>> TDPredictor<S> for TDLambda<S, P> {
     fn handle_td_error(&mut self, sample: &Self::Sample, error: f64) {
         let phi_s = self.fa_theta.projector.project(&sample.0);
 

--- a/src/agents/prediction/td.rs
+++ b/src/agents/prediction/td.rs
@@ -2,11 +2,9 @@ use Parameter;
 use agents::{Agent, Predictor, TDPredictor};
 use agents::memory::Trace;
 use fa::{Approximator, Projection, Projector, SimpleLinear, VFunction};
-use geometry::Space;
-
 use std::marker::PhantomData;
 
-pub struct TD<S: Space, V: VFunction<S::Repr>> {
+pub struct TD<S: ?Sized, V: VFunction<S>> {
     pub v_func: V,
 
     pub alpha: Parameter,
@@ -15,7 +13,7 @@ pub struct TD<S: Space, V: VFunction<S::Repr>> {
     phantom: PhantomData<S>,
 }
 
-impl<S: Space, V: VFunction<S::Repr>> TD<S, V> {
+impl<S: ?Sized, V: VFunction<S>> TD<S, V> {
     pub fn new<T1, T2>(v_func: V, alpha: T1, gamma: T2) -> Self
     where
         T1: Into<Parameter>,
@@ -32,8 +30,8 @@ impl<S: Space, V: VFunction<S::Repr>> TD<S, V> {
     }
 }
 
-impl<S: Space, V: VFunction<S::Repr>> Agent for TD<S, V> {
-    type Sample = (S::Repr, S::Repr, f64);
+impl<S: Sized, V: VFunction<S>> Agent for TD<S, V> {
+    type Sample = (S, S, f64);
 
     fn handle_sample(&mut self, sample: &Self::Sample) {
         let td_error = self.compute_td_error(sample);
@@ -47,11 +45,11 @@ impl<S: Space, V: VFunction<S::Repr>> Agent for TD<S, V> {
     }
 }
 
-impl<S: Space, V: VFunction<S::Repr>> Predictor<S> for TD<S, V> {
-    fn evaluate(&self, s: &S::Repr) -> f64 { self.v_func.evaluate(s).unwrap() }
+impl<S: Sized, V: VFunction<S>> Predictor<S> for TD<S, V> {
+    fn evaluate(&self, s: &S) -> f64 { self.v_func.evaluate(s).unwrap() }
 }
 
-impl<S: Space, V: VFunction<S::Repr>> TDPredictor<S> for TD<S, V> {
+impl<S: Sized, V: VFunction<S>> TDPredictor<S> for TD<S, V> {
     fn handle_td_error(&mut self, sample: &Self::Sample, error: f64) {
         let _ = self.v_func.update(&sample.0, self.alpha * error);
     }
@@ -64,19 +62,19 @@ impl<S: Space, V: VFunction<S::Repr>> TDPredictor<S> for TD<S, V> {
     }
 }
 
-pub struct TDLambda<S: Space, P: Projector<S::Repr>> {
+pub struct TDLambda<S: ?Sized, P: Projector<S>> {
     trace: Trace,
 
-    pub fa_theta: SimpleLinear<S::Repr, P>,
+    pub fa_theta: SimpleLinear<S, P>,
 
     pub alpha: Parameter,
     pub gamma: Parameter,
 }
 
-impl<S: Space, P: Projector<S::Repr>> TDLambda<S, P> {
+impl<S: ?Sized, P: Projector<S>> TDLambda<S, P> {
     pub fn new<T1, T2>(
         trace: Trace,
-        fa_theta: SimpleLinear<S::Repr, P>,
+        fa_theta: SimpleLinear<S, P>,
         alpha: T1,
         gamma: T2,
     ) -> Self
@@ -113,8 +111,8 @@ impl<S: Space, P: Projector<S::Repr>> TDLambda<S, P> {
     }
 }
 
-impl<S: Space, P: Projector<S::Repr>> Agent for TDLambda<S, P> {
-    type Sample = (S::Repr, S::Repr, f64);
+impl<S: Sized, P: Projector<S>> Agent for TDLambda<S, P> {
+    type Sample = (S, S, f64);
 
     fn handle_sample(&mut self, sample: &Self::Sample) {
         let phi_s = self.fa_theta.projector.project(&sample.0);
@@ -133,11 +131,11 @@ impl<S: Space, P: Projector<S::Repr>> Agent for TDLambda<S, P> {
     }
 }
 
-impl<S: Space, P: Projector<S::Repr>> Predictor<S> for TDLambda<S, P> {
-    fn evaluate(&self, s: &S::Repr) -> f64 { self.fa_theta.evaluate(s).unwrap() }
+impl<S: Sized, P: Projector<S>> Predictor<S> for TDLambda<S, P> {
+    fn evaluate(&self, s: &S) -> f64 { self.fa_theta.evaluate(s).unwrap() }
 }
 
-impl<S: Space, P: Projector<S::Repr>> TDPredictor<S> for TDLambda<S, P> {
+impl<S: Sized, P: Projector<S>> TDPredictor<S> for TDLambda<S, P> {
     fn handle_td_error(&mut self, sample: &Self::Sample, error: f64) {
         let phi_s = self.fa_theta.projector.project(&sample.0);
 

--- a/src/domains/acrobat.rs
+++ b/src/domains/acrobat.rs
@@ -120,7 +120,7 @@ impl Domain for Acrobat {
     type StateSpace = RegularSpace<Continuous>;
     type ActionSpace = ActionSpace;
 
-    fn emit(&self) -> Observation<Self::StateSpace, Self::ActionSpace> {
+    fn emit(&self) -> Observation<Vec<f64>, usize> {
         if self.is_terminal() {
             Observation::Terminal(self.state.to_vec())
         } else {
@@ -131,7 +131,7 @@ impl Domain for Acrobat {
         }
     }
 
-    fn step(&mut self, a: usize) -> Transition<Self::StateSpace, Self::ActionSpace> {
+    fn step(&mut self, a: usize) -> Transition<Vec<f64>, usize> {
         let from = self.emit();
 
         self.update_state(a);
@@ -155,8 +155,8 @@ impl Domain for Acrobat {
 
     fn reward(
         &self,
-        _: &Observation<Self::StateSpace, Self::ActionSpace>,
-        to: &Observation<Self::StateSpace, Self::ActionSpace>,
+        _: &Observation<Vec<f64>, usize>,
+        to: &Observation<Vec<f64>, usize>,
     ) -> f64
     {
         match to {

--- a/src/domains/cart_pole.rs
+++ b/src/domains/cart_pole.rs
@@ -97,7 +97,7 @@ impl Domain for CartPole {
     type StateSpace = RegularSpace<Continuous>;
     type ActionSpace = ActionSpace;
 
-    fn emit(&self) -> Observation<Self::StateSpace, Self::ActionSpace> {
+    fn emit(&self) -> Observation<Vec<f64>, usize> {
         if self.is_terminal() {
             Observation::Terminal(self.state.to_vec())
         } else {
@@ -108,7 +108,7 @@ impl Domain for CartPole {
         }
     }
 
-    fn step(&mut self, a: usize) -> Transition<Self::StateSpace, Self::ActionSpace> {
+    fn step(&mut self, a: usize) -> Transition<Vec<f64>, usize> {
         let from = self.emit();
 
         self.update_state(a);
@@ -132,8 +132,8 @@ impl Domain for CartPole {
 
     fn reward(
         &self,
-        _: &Observation<Self::StateSpace, Self::ActionSpace>,
-        to: &Observation<Self::StateSpace, Self::ActionSpace>,
+        _: &Observation<Vec<f64>, usize>,
+        to: &Observation<Vec<f64>, usize>,
     ) -> f64
     {
         match to {

--- a/src/domains/cliff_walk.rs
+++ b/src/domains/cliff_walk.rs
@@ -37,7 +37,7 @@ impl Domain for CliffWalk {
     type StateSpace = PairSpace<Discrete, Discrete>;
     type ActionSpace = ActionSpace;
 
-    fn emit(&self) -> Observation<Self::StateSpace, Self::ActionSpace> {
+    fn emit(&self) -> Observation<(usize, usize), usize> {
         if self.is_terminal() {
             Observation::Terminal(self.loc)
         } else {
@@ -48,7 +48,7 @@ impl Domain for CliffWalk {
         }
     }
 
-    fn step(&mut self, a: usize) -> Transition<Self::StateSpace, Self::ActionSpace> {
+    fn step(&mut self, a: usize) -> Transition<(usize, usize), usize> {
         let from = self.emit();
 
         self.update_state(a);
@@ -65,8 +65,8 @@ impl Domain for CliffWalk {
 
     fn reward(
         &self,
-        from: &Observation<Self::StateSpace, Self::ActionSpace>,
-        to: &Observation<Self::StateSpace, Self::ActionSpace>,
+        from: &Observation<(usize, usize), usize>,
+        to: &Observation<(usize, usize), usize>,
     ) -> f64
     {
         match to {

--- a/src/domains/hiv.rs
+++ b/src/domains/hiv.rs
@@ -127,7 +127,7 @@ impl Domain for HIVTreatment {
     type StateSpace = RegularSpace<Continuous>;
     type ActionSpace = ActionSpace;
 
-    fn emit(&self) -> Observation<Self::StateSpace, Self::ActionSpace> {
+    fn emit(&self) -> Observation<Vec<f64>, usize> {
         let s = self.state.mapv(|v| clip!(LIMITS.0, v.log10(), LIMITS.1)).to_vec();
 
         if self.is_terminal() {
@@ -140,7 +140,7 @@ impl Domain for HIVTreatment {
         }
     }
 
-    fn step(&mut self, a: usize) -> Transition<Self::StateSpace, Self::ActionSpace> {
+    fn step(&mut self, a: usize) -> Transition<Vec<f64>, usize> {
         let from = self.emit();
 
         self.update_state(a);
@@ -159,8 +159,8 @@ impl Domain for HIVTreatment {
 
     fn reward(
         &self,
-        _: &Observation<Self::StateSpace, Self::ActionSpace>,
-        to: &Observation<Self::StateSpace, Self::ActionSpace>,
+        _: &Observation<Vec<f64>, usize>,
+        to: &Observation<Vec<f64>, usize>,
     ) -> f64
     {
         let s = to.state();

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -5,33 +5,33 @@ use geometry::dimensions;
 use geometry::dimensions::Dimension;
 
 /// Container class for data associated with a domain observation.
-pub enum Observation<S: Space, A: Space> {
+pub enum Observation<S, A> {
     /// Fully observed state of the environment.
     Full {
         /// Current state of the environment.
-        state: S::Repr,
+        state: S,
 
         /// Set of available actions.
-        actions: Vec<A::Repr>,
+        actions: Vec<A>,
     },
 
     /// Partially observed state of the environment.
     Partial {
         /// Current state of the environment.
-        state: S::Repr,
+        state: S,
 
         /// Set of available actions.
-        actions: Vec<A::Repr>,
+        actions: Vec<A>,
     },
 
     /// Terminal state of the environment.
-    Terminal(S::Repr),
+    Terminal(S),
 }
 
-impl<S: Space, A: Space> Observation<S, A> {
+impl<S, A> Observation<S, A> {
     /// Helper function returning a reference to the state values for the given
     /// observation.
-    pub fn state(&self) -> &S::Repr {
+    pub fn state(&self) -> &S {
         use self::Observation::*;
 
         match self {
@@ -41,12 +41,12 @@ impl<S: Space, A: Space> Observation<S, A> {
 }
 
 /// Container class for data associated with a domain transition.
-pub struct Transition<S: Space, A: Space> {
+pub struct Transition<S, A> {
     /// State transitioned _from_, `s`.
     pub from: Observation<S, A>,
 
     /// Action taken to initiate the transition.
-    pub action: A::Repr,
+    pub action: A,
 
     /// Reward obtained from the transition.
     pub reward: f64,
@@ -64,13 +64,14 @@ pub trait Domain {
     type ActionSpace: Space;
 
     /// Emit an observation of the current state of the environment.
-    fn emit(&self) -> Observation<Self::StateSpace, Self::ActionSpace>;
+    fn emit(&self) -> Observation<<Self::StateSpace as Space>::Repr,
+                                  <Self::ActionSpace as Space>::Repr>;
 
     /// Transition the environment forward a single step given an action, `a`.
     fn step(
         &mut self,
         a: <dimensions::Discrete as Dimension>::Value,
-    ) -> Transition<Self::StateSpace, Self::ActionSpace>;
+    ) -> Transition<<Self::StateSpace as Space>::Repr, <Self::ActionSpace as Space>::Repr>;
 
     /// Returns true if the current state is terminal.
     fn is_terminal(&self) -> bool;
@@ -79,8 +80,8 @@ pub trait Domain {
     /// another.
     fn reward(
         &self,
-        from: &Observation<Self::StateSpace, Self::ActionSpace>,
-        to: &Observation<Self::StateSpace, Self::ActionSpace>,
+        from: &Observation<<Self::StateSpace as Space>::Repr, <Self::ActionSpace as Space>::Repr>,
+        to: &Observation<<Self::StateSpace as Space>::Repr, <Self::ActionSpace as Space>::Repr>,
     ) -> f64;
 
     /// Returns an instance of the state space type class.

--- a/src/domains/mountain_car.rs
+++ b/src/domains/mountain_car.rs
@@ -70,7 +70,7 @@ impl Domain for MountainCar {
     type StateSpace = RegularSpace<Continuous>;
     type ActionSpace = ActionSpace;
 
-    fn emit(&self) -> Observation<Self::StateSpace, Self::ActionSpace> {
+    fn emit(&self) -> Observation<Vec<f64>, usize> {
         let s = vec![self.x, self.v];
 
         if self.is_terminal() {
@@ -83,7 +83,7 @@ impl Domain for MountainCar {
         }
     }
 
-    fn step(&mut self, a: usize) -> Transition<Self::StateSpace, Self::ActionSpace> {
+    fn step(&mut self, a: usize) -> Transition<Vec<f64>, usize> {
         let from = self.emit();
 
         self.update_state(a);
@@ -102,8 +102,8 @@ impl Domain for MountainCar {
 
     fn reward(
         &self,
-        _: &Observation<Self::StateSpace, Self::ActionSpace>,
-        to: &Observation<Self::StateSpace, Self::ActionSpace>,
+        _: &Observation<Vec<f64>, usize>,
+        to: &Observation<Vec<f64>, usize>,
     ) -> f64
     {
         match to {

--- a/src/domains/openai/mod.rs
+++ b/src/domains/openai/mod.rs
@@ -81,7 +81,7 @@ impl Domain for OpenAIGym {
     type StateSpace = RegularSpace<Continuous>;
     type ActionSpace = ActionSpace;
 
-    fn emit(&self) -> Observation<Self::StateSpace, Self::ActionSpace> {
+    fn emit(&self) -> Observation<Vec<f64>, usize> {
         if self.is_terminal() {
             Observation::Terminal(self.state.clone())
         } else {
@@ -92,7 +92,7 @@ impl Domain for OpenAIGym {
         }
     }
 
-    fn step(&mut self, a: usize) -> Transition<Self::StateSpace, Self::ActionSpace> {
+    fn step(&mut self, a: usize) -> Transition<Vec<f64>, usize> {
         let from = self.emit();
 
         self.update_state(a);
@@ -110,8 +110,8 @@ impl Domain for OpenAIGym {
 
     fn reward(
         &self,
-        _: &Observation<Self::StateSpace, Self::ActionSpace>,
-        _: &Observation<Self::StateSpace, Self::ActionSpace>,
+        _: &Observation<Vec<f64>, usize>,
+        _: &Observation<Vec<f64>, usize>,
     ) -> f64
     {
         self.last_reward

--- a/src/experiment.rs
+++ b/src/experiment.rs
@@ -50,7 +50,7 @@ pub struct Evaluation<'a, A: 'a, D> {
 
 impl<'a, S: Space, A, D> Evaluation<'a, A, D>
 where
-    A: Controller<S, ActionSpace>,
+    A: Controller<S::Repr, <ActionSpace as Space>::Repr>,
     D: Domain<StateSpace = S, ActionSpace = ActionSpace>,
 {
     pub fn new(agent: &'a mut A, domain_factory: Box<Fn() -> D>) -> Evaluation<'a, A, D> {
@@ -65,7 +65,7 @@ where
 
 impl<'a, S: Space, A, D> Iterator for Evaluation<'a, A, D>
 where
-    A: Controller<S, ActionSpace>,
+    A: Controller<S::Repr, <ActionSpace as Space>::Repr>,
     D: Domain<StateSpace = S, ActionSpace = ActionSpace>,
 {
     type Item = Episode;
@@ -109,7 +109,7 @@ pub struct SerialExperiment<'a, A: 'a, D> {
 
 impl<'a, S: Space, A, D> SerialExperiment<'a, A, D>
 where
-    A: Controller<S, ActionSpace>,
+    A: Controller<S::Repr, <ActionSpace as Space>::Repr>,
     D: Domain<StateSpace = S, ActionSpace = ActionSpace>,
 {
     pub fn new(
@@ -128,7 +128,7 @@ where
 
 impl<'a, S: Space, A, D> Iterator for SerialExperiment<'a, A, D>
 where
-    A: Controller<S, ActionSpace>,
+    A: Controller<S::Repr, <ActionSpace as Space>::Repr>,
     D: Domain<StateSpace = S, ActionSpace = ActionSpace>,
 {
     type Item = Episode;


### PR DESCRIPTION
The `Space` types are incredibly useful for defining the input/output spaces produces by basis projectors, by function approximators, by domains, etc etc. However, there's no need to actually enforce the requirement that state space and action spaces representation types are actually embedded in some `Space::Repr` implementation. Though this does give some nice mathematical properties, it add a lot of unnecessary complexity to the code base for not a lot of gain.

We will keep using these types, but it will be restricted to the places where we _actually need_ it to help with the implementation. For example, we will keep the Domain::StateSpace and Domain::ActionSpace types.