### PR TITLE
Correct terminal state handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ default = []
 openai = ["cpython"]
 
 [dependencies]
-lfa = "0.4"
-spaces = "2.2"
+spaces = "4.1"
+lfa = "0.6"
 
 rand = "0.5"
 cpython = { version = "0.2", optional = true }

--- a/examples/a2c.rs
+++ b/examples/a2c.rs
@@ -7,7 +7,7 @@ use rsrl::{
     control::td::SARSA,
     core::{make_shared, run, Evaluation, Parameter, SerialExperiment, Trace},
     domains::{Domain, MountainCar},
-    fa::{projectors::fixed::Fourier, LFA},
+    fa::{basis::fixed::Fourier, LFA},
     geometry::Space,
     logging,
     policies::parameterised::Gibbs,
@@ -22,7 +22,7 @@ fn main() {
     let policy = {
         // Build the linear value function using a fourier basis projection and the
         // appropriate eligibility trace.
-        let fa = LFA::multi(bases.clone(), n_actions);
+        let fa = LFA::vector_valued(bases.clone(), n_actions);
 
         // Build a stochastic behaviour policy with exponential epsilon.
         make_shared(Gibbs::new(fa))
@@ -30,12 +30,12 @@ fn main() {
     let critic = {
         // Build the linear value function using a fourier basis projection and the
         // appropriate eligibility trace.
-        let q_func = make_shared(LFA::multi(bases, n_actions));
+        let q_func = make_shared(LFA::vector_valued(bases, n_actions));
 
-        SARSA::new(q_func, policy.clone(), 0.1, 0.99)
+        SARSA::new(q_func, policy.clone(), 0.001, 0.99)
     };
 
-    let mut agent = A2C::new(critic, policy, 0.1);
+    let mut agent = A2C::new(critic, policy, 0.01);
 
     let logger = logging::root(logging::stdout());
     let domain_builder = Box::new(MountainCar::default);

--- a/examples/greedy_gq.rs
+++ b/examples/greedy_gq.rs
@@ -6,7 +6,7 @@ use rsrl::{
     control::gtd::GreedyGQ,
     core::{make_shared, run, Evaluation, Parameter, SerialExperiment, Trace},
     domains::{Domain, MountainCar},
-    fa::{projectors::fixed::Fourier, LFA},
+    fa::{basis::fixed::Fourier, LFA},
     geometry::Space,
     logging,
     policies::fixed::EpsilonGreedy,
@@ -21,14 +21,14 @@ fn main() {
 
         // Build the linear value functions using a fourier basis projection.
         let bases = Fourier::from_space(3, domain.state_space());
-        let v_func = make_shared(LFA::simple(bases.clone()));
-        let q_func = make_shared(LFA::multi(bases, n_actions));
+        let v_func = make_shared(LFA::scalar_valued(bases.clone()));
+        let q_func = make_shared(LFA::vector_valued(bases, n_actions));
 
         // Build a stochastic behaviour policy with exponential epsilon.
         let eps = Parameter::exponential(0.99, 0.05, 0.99);
         let policy = make_shared(EpsilonGreedy::new(q_func.clone(), eps));
 
-        GreedyGQ::new(q_func, v_func, policy, 1e-1, 1e-3, 0.99)
+        GreedyGQ::new(q_func, v_func, policy, 1e-3, 1e-4, 0.99)
     };
 
     let domain_builder = Box::new(MountainCar::default);

--- a/examples/nac.rs
+++ b/examples/nac.rs
@@ -7,7 +7,7 @@ use rsrl::{
     control::td::SARSA,
     core::{make_shared, run, Evaluation, Parameter, SerialExperiment, Trace},
     domains::{Domain, MountainCar},
-    fa::{projectors::fixed::Fourier, LFA},
+    fa::{basis::fixed::Fourier, LFA},
     geometry::Space,
     logging,
     policies::parameterised::Gibbs,
@@ -22,7 +22,7 @@ fn main() {
     let policy = {
         // Build the linear value function using a fourier basis projection and the
         // appropriate eligibility trace.
-        let fa = LFA::multi(bases.clone(), n_actions);
+        let fa = LFA::vector_valued(bases.clone(), n_actions);
 
         // Build a stochastic behaviour policy with exponential epsilon.
         make_shared(Gibbs::new(fa))
@@ -30,12 +30,12 @@ fn main() {
     let critic = {
         // Build the linear value function using a fourier basis projection and the
         // appropriate eligibility trace.
-        let q_func = make_shared(LFA::multi(bases, n_actions));
+        let q_func = make_shared(LFA::vector_valued(bases, n_actions));
 
-        SARSA::new(q_func, policy.clone(), 0.1, 0.99)
+        SARSA::new(q_func, policy.clone(), 0.001, 0.99)
     };
 
-    let mut agent = NAC::new(critic, policy, 0.1);
+    let mut agent = NAC::new(critic, policy, 0.01);
 
     let logger = logging::root(logging::stdout());
     let domain_builder = Box::new(MountainCar::default);

--- a/examples/pal.rs
+++ b/examples/pal.rs
@@ -6,7 +6,7 @@ use rsrl::{
     control::td::PAL,
     core::{make_shared, run, Evaluation, Parameter, SerialExperiment, Trace},
     domains::{Domain, MountainCar},
-    fa::{projectors::fixed::Fourier, LFA},
+    fa::{basis::fixed::Fourier, LFA},
     geometry::Space,
     logging,
     policies::fixed::EpsilonGreedy,
@@ -20,7 +20,7 @@ fn main() {
         // Build the linear value function using a fourier basis projection and the
         // appropriate eligibility trace.
         let bases = Fourier::from_space(3, domain.state_space());
-        let q_func = make_shared(LFA::multi(bases, n_actions));
+        let q_func = make_shared(LFA::vector_valued(bases, n_actions));
 
         // Build a stochastic behaviour policy with exponential epsilon.
         let eps = Parameter::exponential(0.99, 0.05, 0.99);

--- a/examples/polynomial.rs
+++ b/examples/polynomial.rs
@@ -6,7 +6,7 @@ use rsrl::{
     control::td::SARSALambda,
     core::{make_shared, run, Evaluation, Parameter, SerialExperiment, Trace},
     domains::{Domain, MountainCar},
-    fa::{projectors::fixed::Polynomial, LFA},
+    fa::{basis::fixed::Chebyshev, LFA},
     geometry::Space,
     logging,
     policies::fixed::EpsilonGreedy,
@@ -19,15 +19,15 @@ fn main() {
 
         // Build the linear value function using a polynomial basis projection and the
         // appropriate eligibility trace.
-        let bases = Polynomial::from_space(5, domain.state_space());
+        let bases = Chebyshev::from_space(5, domain.state_space());
         let trace = Trace::replacing(0.7, bases.dim());
-        let q_func = make_shared(LFA::multi(bases, n_actions));
+        let q_func = make_shared(LFA::vector_valued(bases, n_actions));
 
         // Build a stochastic behaviour policy with exponential epsilon.
         let eps = Parameter::exponential(0.99, 0.05, 0.99);
         let policy = make_shared(EpsilonGreedy::new(q_func.clone(), eps));
 
-        SARSALambda::new(trace, q_func, policy, 0.1, 0.99)
+        SARSALambda::new(trace, q_func, policy, 0.001, 0.99)
     };
 
     let logger = logging::root(logging::stdout());

--- a/examples/reinforce.rs
+++ b/examples/reinforce.rs
@@ -6,7 +6,7 @@ use rsrl::{
     control::mc::REINFORCE,
     core::{make_shared, run, Evaluation, SerialExperiment},
     domains::{ContinuousMountainCar, Domain},
-    fa::{projectors::fixed::Fourier, LFA},
+    fa::{basis::fixed::KernelProjector, LFA},
     logging,
     policies::parameterised::Gaussian1d,
 };
@@ -16,14 +16,14 @@ fn main() {
     let policy = {
         // Build the linear value function using a fourier basis projection and the
         // appropriate eligibility trace.
-        let bases = Fourier::from_space(5, domain.state_space());
-        let fa = LFA::simple(bases.clone());
+        let bases = KernelProjector::rbf_network(domain.state_space().partitioned(10));
+        let fa = LFA::scalar_valued(bases.clone());
 
         // Build a stochastic behaviour policy with exponential epsilon.
         Gaussian1d::new(fa, 1.0)
     };
 
-    let mut agent = REINFORCE::new(make_shared(policy), 0.01, 0.99);
+    let mut agent = REINFORCE::new(make_shared(policy), 2e-4, 0.99);
 
     let logger = logging::root(logging::stdout());
     let domain_builder = Box::new(ContinuousMountainCar::default);
@@ -34,7 +34,7 @@ fn main() {
         let e = SerialExperiment::new(&mut agent, domain_builder.clone(), 1000);
 
         // Realise 1000 episodes of the experiment generator.
-        run(e, 10000, Some(logger.clone()))
+        run(e, 1000, Some(logger.clone()))
     };
 
     // Testing phase:

--- a/examples/sarsa_lambda.rs
+++ b/examples/sarsa_lambda.rs
@@ -6,7 +6,7 @@ use rsrl::{
     control::td::SARSALambda,
     core::{make_shared, run, Evaluation, Parameter, SerialExperiment, Trace},
     domains::{Domain, MountainCar},
-    fa::{projectors::fixed::Fourier, LFA},
+    fa::{basis::fixed::Fourier, LFA},
     geometry::Space,
     logging,
     policies::fixed::EpsilonGreedy,
@@ -21,7 +21,7 @@ fn main() {
         // appropriate eligibility trace.
         let bases = Fourier::from_space(3, domain.state_space());
         let trace = Trace::replacing(0.7, bases.dim());
-        let q_func = make_shared(LFA::multi(bases, n_actions));
+        let q_func = make_shared(LFA::vector_valued(bases, n_actions));
 
         // Build a stochastic behaviour policy with exponential epsilon.
         let eps = Parameter::exponential(0.99, 0.05, 0.99);

--- a/src/control/actor_critic/a2c.rs
+++ b/src/control/actor_critic/a2c.rs
@@ -34,6 +34,22 @@ where
     }
 }
 
+impl<S, C, P> A2C<S, C, P>
+where
+    C: Predictor<S, P::Action>,
+    P: ParameterisedPolicy<S>,
+    P::Action: Copy,
+{
+    #[inline(always)]
+    fn update_policy(&mut self, t: &Transition<S, P::Action>) {
+        let s = t.from.state();
+        let v = self.critic.predict_v(s);
+        let qsa = self.critic.predict_qsa(s, t.action);
+
+        self.policy.borrow_mut().update(s, t.action, self.alpha * (qsa - v));
+    }
+}
+
 impl<S: Clone, C, P> Algorithm<S, P::Action> for A2C<S, C, P>
 where
     C: Predictor<S, P::Action>,
@@ -42,19 +58,16 @@ where
 {
     fn handle_sample(&mut self, t: &Transition<S, P::Action>) {
         self.critic.handle_sample(t);
-
-        let s = t.from.state();
-        let v = self.critic.predict_v(s);
-        let qsa = self.critic.predict_qsa(s, t.action);
-
-        self.policy.borrow_mut().update(s, t.action, self.alpha * (qsa - v));
+        self.update_policy(t);
     }
 
     fn handle_terminal(&mut self, t: &Transition<S, P::Action>) {
-        self.alpha = self.alpha.step();
-
         self.critic.handle_terminal(t);
+
+        self.update_policy(t);
         self.policy.borrow_mut().handle_terminal(t);
+
+        self.alpha = self.alpha.step();
     }
 }
 

--- a/src/control/actor_critic/a2c.rs
+++ b/src/control/actor_critic/a2c.rs
@@ -62,10 +62,12 @@ where
     }
 
     fn handle_terminal(&mut self, t: &Transition<S, P::Action>) {
-        self.critic.handle_terminal(t);
+        {
+            self.critic.handle_terminal(t);
 
-        self.update_policy(t);
-        self.policy.borrow_mut().handle_terminal(t);
+            self.update_policy(t);
+            self.policy.borrow_mut().handle_terminal(t);
+        }
 
         self.alpha = self.alpha.step();
     }

--- a/src/control/actor_critic/nac.rs
+++ b/src/control/actor_critic/nac.rs
@@ -61,10 +61,12 @@ where
     }
 
     fn handle_terminal(&mut self, t: &Transition<S, P::Action>) {
-        self.critic.handle_terminal(t);
+        {
+            self.critic.handle_terminal(t);
 
-        self.update_policy();
-        self.policy.borrow_mut().handle_terminal(t);
+            self.update_policy();
+            self.policy.borrow_mut().handle_terminal(t);
+        }
 
         self.alpha = self.alpha.step();
     }

--- a/src/control/actor_critic/qac.rs
+++ b/src/control/actor_critic/qac.rs
@@ -61,10 +61,12 @@ where
     }
 
     fn handle_terminal(&mut self, t: &Transition<S, P::Action>) {
-        self.critic.handle_terminal(t);
+        {
+            self.critic.handle_terminal(t);
 
-        self.update_policy(t);
-        self.policy.borrow_mut().handle_terminal(t);
+            self.update_policy(t);
+            self.policy.borrow_mut().handle_terminal(t);
+        }
 
         self.alpha = self.alpha.step();
     }

--- a/src/control/actor_critic/tdac.rs
+++ b/src/control/actor_critic/tdac.rs
@@ -40,15 +40,14 @@ where
     }
 }
 
-impl<S: Clone, C, P> Algorithm<S, P::Action> for TDAC<S, C, P>
+impl<S, C, P> TDAC<S, C, P>
 where
     C: Predictor<S, P::Action>,
     P: ParameterisedPolicy<S>,
     P::Action: Copy,
 {
-    fn handle_sample(&mut self, t: &Transition<S, P::Action>) {
-        self.critic.handle_sample(t);
-
+    #[inline(always)]
+    fn update_policy(&mut self, t: &Transition<S, P::Action>) {
         let (s, ns) = (t.from.state(), t.to.state());
 
         let v = self.critic.predict_v(s);
@@ -57,13 +56,27 @@ where
 
         self.policy.borrow_mut().update(s, t.action, self.alpha * td_error);
     }
+}
+
+impl<S: Clone, C, P> Algorithm<S, P::Action> for TDAC<S, C, P>
+where
+    C: Predictor<S, P::Action>,
+    P: ParameterisedPolicy<S>,
+    P::Action: Copy,
+{
+    fn handle_sample(&mut self, t: &Transition<S, P::Action>) {
+        self.critic.handle_sample(t);
+        self.update_policy(t);
+    }
 
     fn handle_terminal(&mut self, t: &Transition<S, P::Action>) {
+        self.critic.handle_terminal(t);
+
+        self.update_policy(t);
+        self.policy.borrow_mut().handle_terminal(t);
+
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
-
-        self.critic.handle_terminal(t);
-        self.policy.borrow_mut().handle_terminal(t);
     }
 }
 

--- a/src/control/actor_critic/tdac.rs
+++ b/src/control/actor_critic/tdac.rs
@@ -70,10 +70,12 @@ where
     }
 
     fn handle_terminal(&mut self, t: &Transition<S, P::Action>) {
-        self.critic.handle_terminal(t);
+        {
+            self.critic.handle_terminal(t);
 
-        self.update_policy(t);
-        self.policy.borrow_mut().handle_terminal(t);
+            self.update_policy(t);
+            self.policy.borrow_mut().handle_terminal(t);
+        }
 
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();

--- a/src/control/gtd/greedy_gq.rs
+++ b/src/control/gtd/greedy_gq.rs
@@ -63,39 +63,63 @@ impl<S: 'static, M: Projector<S> + 'static, P: Policy<S>> GreedyGQ<S, M, P> {
     }
 }
 
+impl<S, M: Projector<S>, P: Policy<S, Action = usize>> GreedyGQ<S, M, P> {
+    #[inline(always)]
+    fn update_theta(&mut self, phi_s: Projection, action: P::Action, phi_ns: Projection,
+                    td_error: f64, td_estimate: f64)
+    {
+        let dim = self.fa_theta.borrow().projector.dim();
+        let update_q =
+            td_error * phi_s.expanded(dim) -
+            td_estimate * self.gamma.value() * phi_ns.expanded(dim);
+
+        self.fa_theta.borrow_mut()
+            .update_action_phi(&Projection::Dense(update_q), action, self.alpha.value());
+    }
+
+    #[inline(always)]
+    fn update_w(&mut self, phi_s: &Projection, error: f64) {
+        self.fa_w.borrow_mut().update_phi(phi_s, self.alpha * self.beta * error);
+    }
+}
+
 impl<S, M: Projector<S>, P: Policy<S, Action = usize>> Algorithm<S, P::Action> for GreedyGQ<S, M, P> {
     fn handle_sample(&mut self, t: &Transition<S, P::Action>) {
         let (s, ns) = (t.from.state(), t.to.state());
 
+        let na = self.sample_target(ns);
         let phi_s = self.fa_w.borrow().projector.project(s);
         let phi_ns = self.fa_w.borrow().projector.project(ns);
-
-        let na = self.sample_target(ns);
 
         let td_estimate = self.fa_w.borrow().evaluate_phi(&phi_s);
         let td_error = t.reward
             + self.gamma.value() * self.fa_theta.borrow().evaluate_action_phi(&phi_ns, na)
             - self.fa_theta.borrow().evaluate_action_phi(&phi_s, t.action);
 
-        let phi_s = phi_s.expanded(self.fa_w.borrow().projector.dim());
-        let phi_ns = phi_ns.expanded(self.fa_w.borrow().projector.dim());
-
-        let update_q = td_error * phi_s.clone() - self.gamma * td_estimate * phi_ns;
-        let update_v = (td_error - td_estimate) * phi_s;
-
-        self.fa_w.borrow_mut()
-            .update_phi(&Projection::Dense(update_v), self.alpha * self.beta);
-        self.fa_theta.borrow_mut()
-            .update_action_phi(&Projection::Dense(update_q), t.action, self.alpha.value());
+        self.update_w(&phi_s, td_error - td_estimate);
+        self.update_theta(phi_s, t.action, phi_ns, td_error, td_estimate);
     }
 
     fn handle_terminal(&mut self, t: &Transition<S, P::Action>) {
+        {
+            let (s, ns) = (t.from.state(), t.to.state());
+
+            let phi_s = self.fa_w.borrow().projector.project(s);
+            let phi_ns = self.fa_w.borrow().projector.project(ns);
+
+            let td_estimate = self.fa_w.borrow().evaluate_phi(&phi_s);
+            let td_error = t.reward - self.fa_theta.borrow().evaluate_action_phi(&phi_s, t.action);
+
+            self.update_w(&phi_s, td_error - td_estimate);
+            self.update_theta(phi_s, t.action, phi_ns, td_error, td_estimate);
+
+            self.policy.borrow_mut().handle_terminal(t);
+            self.target.handle_terminal(t);
+        }
+
         self.alpha = self.alpha.step();
         self.beta = self.beta.step();
         self.gamma = self.gamma.step();
-
-        self.policy.borrow_mut().handle_terminal(t);
-        self.target.handle_terminal(t);
     }
 }
 

--- a/src/control/mc/reinforce.rs
+++ b/src/control/mc/reinforce.rs
@@ -34,12 +34,12 @@ impl<S, P: ParameterisedPolicy<S>> REINFORCE<S, P> {
     }
 
     pub fn propagate(&mut self) {
-        let mut sum = 0.0;
+        let mut ret = 0.0;
 
         for (s, a, r) in self.cache.drain(0..).rev() {
-            sum = r + self.gamma * sum;
+            ret = r + self.gamma * ret;
 
-            self.policy.borrow_mut().update(&s, a, self.alpha * sum);
+            self.policy.borrow_mut().update(&s, a, self.alpha * ret);
         }
     }
 }

--- a/src/control/mc/reinforce.rs
+++ b/src/control/mc/reinforce.rs
@@ -1,4 +1,4 @@
-use core::{Algorithm, Controller, Parameter, Shared};
+use core::{Algorithm, Controller, Predictor, Parameter, Shared};
 use domains::Transition;
 use geometry::Matrix;
 use fa::Parameterised;
@@ -53,7 +53,9 @@ where
     }
 
     fn handle_terminal(&mut self, _: &Transition<S, P::Action>) {
-        self.propagate();
+        {
+            self.propagate();
+        }
 
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
@@ -70,6 +72,97 @@ where
 }
 
 impl<S, P: Policy<S> + Parameterised> Parameterised for REINFORCE<S, P> {
+    fn weights(&self) -> Matrix<f64> {
+        self.policy.borrow().weights()
+    }
+}
+
+
+pub struct BaselineREINFORCE<S, P: Policy<S>, C: Predictor<S, P::Action>> {
+    pub policy: Shared<P>,
+    pub baseline: C,
+    pub cache: Vec<(S, P::Action, f64)>,
+
+    pub alpha: Parameter,
+    pub gamma: Parameter,
+
+    phantom: PhantomData<S>,
+}
+
+impl<S, P, C> BaselineREINFORCE<S, P, C>
+where
+    P: ParameterisedPolicy<S>,
+    C: Predictor<S, P::Action>,
+{
+    pub fn new<T1, T2>(policy: Shared<P>, baseline: C, alpha: T1, gamma: T2) -> Self
+    where
+        T1: Into<Parameter>,
+        T2: Into<Parameter>,
+    {
+        BaselineREINFORCE {
+            policy,
+            baseline,
+
+            cache: vec![],
+
+            alpha: alpha.into(),
+            gamma: gamma.into(),
+
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn propagate(&mut self) {
+        let mut ret = 0.0;
+
+        for (s, a, r) in self.cache.drain(0..).rev() {
+            let baseline = self.baseline.predict_v(&s);
+
+            ret = r + self.gamma * ret;
+
+            self.policy.borrow_mut().update(&s, a, self.alpha * (ret - baseline));
+        }
+    }
+}
+
+impl<S: Clone, P, C> Algorithm<S, P::Action> for BaselineREINFORCE<S, P, C>
+where
+    P: ParameterisedPolicy<S>,
+    P::Action: Clone,
+    C: Predictor<S, P::Action>,
+{
+    fn handle_sample(&mut self, t: &Transition<S, P::Action>) {
+        self.baseline.handle_sample(t);
+        self.cache.push((t.from.state().clone(), t.action.clone(), t.reward));
+    }
+
+    fn handle_terminal(&mut self, t: &Transition<S, P::Action>) {
+        self.baseline.handle_terminal(t);
+
+        self.propagate();
+
+        self.alpha = self.alpha.step();
+        self.gamma = self.gamma.step();
+    }
+}
+
+impl<S: Clone, P, C> Controller<S, P::Action> for BaselineREINFORCE<S, P, C>
+where
+    P: ParameterisedPolicy<S>,
+    P::Action: Clone,
+    C: Predictor<S, P::Action>,
+{
+    fn sample_target(&mut self, s: &S) -> P::Action { self.policy.borrow_mut().sample(s) }
+
+    fn sample_behaviour(&mut self, s: &S) -> P::Action { self.policy.borrow_mut().sample(s) }
+}
+
+impl<S, P, C> Parameterised for BaselineREINFORCE<S, P, C>
+where
+    P: ParameterisedPolicy<S>,
+    P::Action: Clone,
+    C: Predictor<S, P::Action>,
+{
     fn weights(&self) -> Matrix<f64> {
         self.policy.borrow().weights()
     }

--- a/src/control/td/expected_sarsa.rs
+++ b/src/control/td/expected_sarsa.rs
@@ -65,9 +65,9 @@ impl<S, Q: QFunction<S>, P: FinitePolicy<S>> Algorithm<S, P::Action> for Expecte
             let qsa = self.predict_qsa(s, t.action);
 
             self.update_q(&s, t.action, t.reward - qsa);
-        }
 
-        self.policy.borrow_mut().handle_terminal(t);
+            self.policy.borrow_mut().handle_terminal(t);
+        }
 
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();

--- a/src/control/td/pal.rs
+++ b/src/control/td/pal.rs
@@ -79,10 +79,10 @@ where
             let qsa = self.predict_qsa(s, t.action);
 
             self.update_q(s, t.action, t.reward - qsa);
-        }
 
-        self.target.handle_terminal(t);
-        self.policy.borrow_mut().handle_terminal(t);
+            self.target.handle_terminal(t);
+            self.policy.borrow_mut().handle_terminal(t);
+        }
 
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();

--- a/src/control/td/pal.rs
+++ b/src/control/td/pal.rs
@@ -45,6 +45,13 @@ where
     }
 }
 
+impl<S, Q: QFunction<S>, P: Policy<S, Action = usize>> PAL<S, Q, P> {
+    #[inline(always)]
+    fn update_q(&mut self, state: &S, action: P::Action, error: f64) {
+        self.q_func.borrow_mut().update_action(state, action, self.alpha * error);
+    }
+}
+
 impl<S, Q, P> Algorithm<S, P::Action> for PAL<S, Q, P>
 where
     Q: QFunction<S>,
@@ -63,15 +70,22 @@ where
         let al_error = td_error - self.alpha * (qs[a_star] - qs[t.action]);
         let pal_error = al_error.max(td_error - self.alpha * (nqs[na_star] - nqs[t.action]));
 
-        self.q_func.borrow_mut().update_action(s, t.action, self.alpha * pal_error);
+        self.update_q(s, t.action, pal_error);
     }
 
     fn handle_terminal(&mut self, t: &Transition<S, P::Action>) {
-        self.alpha = self.alpha.step();
-        self.gamma = self.gamma.step();
+        {
+            let s = t.from.state();
+            let qsa = self.predict_qsa(s, t.action);
+
+            self.update_q(s, t.action, t.reward - qsa);
+        }
 
         self.target.handle_terminal(t);
         self.policy.borrow_mut().handle_terminal(t);
+
+        self.alpha = self.alpha.step();
+        self.gamma = self.gamma.step();
     }
 }
 

--- a/src/control/td/q_learning.rs
+++ b/src/control/td/q_learning.rs
@@ -69,12 +69,12 @@ impl<S, Q: QFunction<S>, P: Policy<S, Action = usize>> Algorithm<S, P::Action> f
             let qsa = self.predict_qsa(&s, t.action);
 
             self.update_q(&s, t.action, t.reward - qsa);
+
+            self.policy.borrow_mut().handle_terminal(t);
         }
 
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
-
-        self.policy.borrow_mut().handle_terminal(t);
     }
 }
 

--- a/src/control/td/q_sigma.rs
+++ b/src/control/td/q_sigma.rs
@@ -171,9 +171,9 @@ where
             });
 
             self.consume_backup();
-        }
 
-        self.policy.borrow_mut().handle_terminal(t);
+            self.policy.borrow_mut().handle_terminal(t);
+        }
 
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();

--- a/src/control/td/sarsa.rs
+++ b/src/control/td/sarsa.rs
@@ -65,11 +65,12 @@ impl<S, Q: QFunction<S>, P: Policy<S, Action = usize>> Algorithm<S, P::Action> f
             let qsa = self.q_func.borrow().evaluate_action(s, t.action);
 
             self.update_q(s, t.action, t.reward - qsa);
+
+            self.policy.borrow_mut().handle_terminal(t);
         }
+
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
-
-        self.policy.borrow_mut().handle_terminal(t);
     }
 }
 

--- a/src/control/td/sarsa.rs
+++ b/src/control/td/sarsa.rs
@@ -39,20 +39,33 @@ impl<S, Q: QFunction<S>, P: Policy<S>> SARSA<S, Q, P> {
     }
 }
 
+impl<S, Q: QFunction<S>, P: Policy<S, Action = usize>> SARSA<S, Q, P> {
+    #[inline(always)]
+    fn update_q(&mut self, state: &S, action: P::Action, error: f64) {
+        self.q_func.borrow_mut().update_action(state, action, self.alpha * error);
+    }
+}
+
 impl<S, Q: QFunction<S>, P: Policy<S, Action = usize>> Algorithm<S, P::Action> for SARSA<S, Q, P> {
     fn handle_sample(&mut self, t: &Transition<S, P::Action>) {
         let (s, ns) = (t.from.state(), t.to.state());
 
         let na = self.policy.borrow_mut().sample(ns);
-        let qa = self.q_func.borrow().evaluate_action(s, t.action);
-        let nqa = self.q_func.borrow().evaluate_action(ns, na);
+        let qsa = self.q_func.borrow().evaluate_action(s, t.action);
+        let nqsna = self.q_func.borrow().evaluate_action(ns, na);
 
-        let td_error = t.reward + self.gamma * nqa - qa;
+        let td_error = t.reward + self.gamma * nqsna - qsa;
 
-        self.q_func.borrow_mut().update_action(s, t.action, self.alpha * td_error);
+        self.update_q(s, t.action, td_error);
     }
 
     fn handle_terminal(&mut self, t: &Transition<S, P::Action>) {
+        {
+            let s = t.from.state();
+            let qsa = self.q_func.borrow().evaluate_action(s, t.action);
+
+            self.update_q(s, t.action, t.reward - qsa);
+        }
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
 

--- a/src/core/experiment.rs
+++ b/src/core/experiment.rs
@@ -147,16 +147,16 @@ where
             e.steps = j;
             e.reward += t.reward;
 
-            self.agent.handle_sample(&t);
-
             // TODO: Clean this mess up!
             if let Observation::Terminal(_) = t.to {
                 self.agent.handle_terminal(&t);
                 break;
             } else if j >= self.step_limit {
-                self.agent.handle_terminal(&t);
+                self.agent.handle_sample(&t);
                 break;
             } else {
+                self.agent.handle_sample(&t);
+
                 a = self.agent.sample_behaviour(&t.to.state());
             }
         }

--- a/src/domains/acrobat.rs
+++ b/src/domains/acrobat.rs
@@ -1,8 +1,9 @@
 use consts::{PI_OVER_2, G};
 use core::Vector;
 use geometry::{
-    dimensions::{Continuous, Discrete},
-    RegularSpace,
+    continuous::Interval,
+    discrete::Ordinal,
+    product::LinearSpace,
 };
 use ndarray::{Ix1, NdIndex};
 use std::f64::consts::PI;
@@ -119,18 +120,18 @@ impl Default for Acrobat {
 }
 
 impl Domain for Acrobat {
-    type StateSpace = RegularSpace<Continuous>;
-    type ActionSpace = Discrete;
+    type StateSpace = LinearSpace<Interval>;
+    type ActionSpace = Ordinal;
 
-    fn emit(&self) -> Observation<Vec<f64>> {
+    fn emit(&self) -> Observation<Vector<f64>> {
         if self.is_terminal() {
-            Observation::Terminal(self.state.to_vec())
+            Observation::Terminal(self.state.clone())
         } else {
-            Observation::Full(self.state.to_vec())
+            Observation::Full(self.state.clone())
         }
     }
 
-    fn step(&mut self, action: usize) -> Transition<Vec<f64>, usize> {
+    fn step(&mut self, action: usize) -> Transition<Vector<f64>, usize> {
         let from = self.emit();
 
         self.update_state(action);
@@ -152,7 +153,7 @@ impl Domain for Acrobat {
         theta1.cos() + (theta1 + theta2).cos() < -1.0
     }
 
-    fn reward(&self, _: &Observation<Vec<f64>>, to: &Observation<Vec<f64>>) -> f64 {
+    fn reward(&self, _: &Observation<Vector<f64>>, to: &Observation<Vector<f64>>) -> f64 {
         match *to {
             Observation::Terminal(_) => REWARD_TERMINAL,
             _ => REWARD_STEP,
@@ -160,13 +161,13 @@ impl Domain for Acrobat {
     }
 
     fn state_space(&self) -> Self::StateSpace {
-        RegularSpace::empty() + Continuous::new(LIMITS_THETA1.0, LIMITS_THETA1.1)
-            + Continuous::new(LIMITS_THETA2.0, LIMITS_THETA2.1)
-            + Continuous::new(LIMITS_DTHETA1.0, LIMITS_DTHETA1.1)
-            + Continuous::new(LIMITS_DTHETA2.0, LIMITS_DTHETA2.1)
+        LinearSpace::empty() + Interval::bounded(LIMITS_THETA1.0, LIMITS_THETA1.1)
+            + Interval::bounded(LIMITS_THETA2.0, LIMITS_THETA2.1)
+            + Interval::bounded(LIMITS_DTHETA1.0, LIMITS_DTHETA1.1)
+            + Interval::bounded(LIMITS_DTHETA2.0, LIMITS_DTHETA2.1)
     }
 
-    fn action_space(&self) -> Discrete { Discrete::new(3) }
+    fn action_space(&self) -> Ordinal { Ordinal::new(3) }
 }
 
 #[cfg(test)]

--- a/src/domains/cart_pole.rs
+++ b/src/domains/cart_pole.rs
@@ -1,8 +1,9 @@
 use consts::{FOUR_THIRDS, G, TWELVE_DEGREES};
-use core::Vector;
 use geometry::{
-    dimensions::{Continuous, Discrete},
-    RegularSpace,
+    continuous::Interval,
+    discrete::Ordinal,
+    product::LinearSpace,
+    Vector,
 };
 use ndarray::{Ix1, NdIndex};
 use super::{runge_kutta4, Domain, Observation, Transition};
@@ -95,18 +96,18 @@ impl Default for CartPole {
 }
 
 impl Domain for CartPole {
-    type StateSpace = RegularSpace<Continuous>;
-    type ActionSpace = Discrete;
+    type StateSpace = LinearSpace<Interval>;
+    type ActionSpace = Ordinal;
 
-    fn emit(&self) -> Observation<Vec<f64>> {
+    fn emit(&self) -> Observation<Vector<f64>> {
         if self.is_terminal() {
-            Observation::Terminal(self.state.to_vec())
+            Observation::Terminal(self.state.clone())
         } else {
-            Observation::Full(self.state.to_vec())
+            Observation::Full(self.state.clone())
         }
     }
 
-    fn step(&mut self, action: usize) -> Transition<Vec<f64>, usize> {
+    fn step(&mut self, action: usize) -> Transition<Vector<f64>, usize> {
         let from = self.emit();
 
         self.update_state(action);
@@ -128,7 +129,7 @@ impl Domain for CartPole {
         x <= LIMITS_X.0 || x >= LIMITS_X.1 || theta <= LIMITS_THETA.0 || theta >= LIMITS_THETA.1
     }
 
-    fn reward(&self, _: &Observation<Vec<f64>>, to: &Observation<Vec<f64>>) -> f64 {
+    fn reward(&self, _: &Observation<Vector<f64>>, to: &Observation<Vector<f64>>) -> f64 {
         match *to {
             Observation::Terminal(_) => REWARD_TERMINAL,
             _ => REWARD_STEP,
@@ -136,13 +137,13 @@ impl Domain for CartPole {
     }
 
     fn state_space(&self) -> Self::StateSpace {
-        RegularSpace::empty() + Continuous::new(LIMITS_X.0, LIMITS_X.1)
-            + Continuous::new(LIMITS_DX.0, LIMITS_DX.1)
-            + Continuous::new(LIMITS_THETA.0, LIMITS_THETA.1)
-            + Continuous::new(LIMITS_DTHETA.0, LIMITS_DTHETA.1)
+        LinearSpace::empty() + Interval::bounded(LIMITS_X.0, LIMITS_X.1)
+            + Interval::bounded(LIMITS_DX.0, LIMITS_DX.1)
+            + Interval::bounded(LIMITS_THETA.0, LIMITS_THETA.1)
+            + Interval::bounded(LIMITS_DTHETA.0, LIMITS_DTHETA.1)
     }
 
-    fn action_space(&self) -> Discrete { Discrete::new(2) }
+    fn action_space(&self) -> Ordinal { Ordinal::new(2) }
 }
 
 #[cfg(test)]

--- a/src/domains/cliff_walk.rs
+++ b/src/domains/cliff_walk.rs
@@ -1,5 +1,5 @@
 use core::Matrix;
-use geometry::{dimensions::Discrete, PairSpace};
+use geometry::{discrete::Ordinal, product::PairSpace};
 use super::{
     grid_world::{GridWorld, Motion},
     Domain,
@@ -37,8 +37,8 @@ impl Default for CliffWalk {
 }
 
 impl Domain for CliffWalk {
-    type StateSpace = PairSpace<Discrete, Discrete>;
-    type ActionSpace = Discrete;
+    type StateSpace = PairSpace<Ordinal, Ordinal>;
+    type ActionSpace = Ordinal;
 
     fn emit(&self) -> Observation<(usize, usize)> {
         if self.is_terminal() {
@@ -91,10 +91,10 @@ impl Domain for CliffWalk {
 
     fn state_space(&self) -> Self::StateSpace {
         PairSpace::new(
-            Discrete::new(self.gw.width()),
-            Discrete::new(self.gw.height()),
+            Ordinal::new(self.gw.width()),
+            Ordinal::new(self.gw.height()),
         )
     }
 
-    fn action_space(&self) -> Discrete { Discrete::new(4) }
+    fn action_space(&self) -> Ordinal { Ordinal::new(4) }
 }

--- a/src/domains/mountain_car/continuous.rs
+++ b/src/domains/mountain_car/continuous.rs
@@ -1,8 +1,9 @@
 use domains::{Domain, Observation, Transition};
 use geometry::{
-    dimensions::Continuous,
-    RegularSpace,
     Surjection,
+    Vector,
+    continuous::Interval,
+    product::LinearSpace,
 };
 
 const X_MIN: f64 = -1.2;
@@ -26,14 +27,14 @@ pub struct ContinuousMountainCar {
     x: f64,
     v: f64,
 
-    action_space: Continuous,
+    action_space: Interval,
 }
 
 impl ContinuousMountainCar {
     fn new(x: f64, v: f64) -> ContinuousMountainCar {
         ContinuousMountainCar {
             x, v,
-            action_space: Continuous::new(MIN_ACTION, MAX_ACTION),
+            action_space: Interval::bounded(MIN_ACTION, MAX_ACTION),
         }
     }
 
@@ -52,11 +53,11 @@ impl Default for ContinuousMountainCar {
 }
 
 impl Domain for ContinuousMountainCar {
-    type StateSpace = RegularSpace<Continuous>;
-    type ActionSpace = Continuous;
+    type StateSpace = LinearSpace<Interval>;
+    type ActionSpace = Interval;
 
-    fn emit(&self) -> Observation<Vec<f64>> {
-        let s = vec![self.x, self.v];
+    fn emit(&self) -> Observation<Vector<f64>> {
+        let s = Vector::from_vec(vec![self.x, self.v]);
 
         if self.is_terminal() {
             Observation::Terminal(s)
@@ -65,7 +66,7 @@ impl Domain for ContinuousMountainCar {
         }
     }
 
-    fn step(&mut self, action: f64) -> Transition<Vec<f64>, f64> {
+    fn step(&mut self, action: f64) -> Transition<Vector<f64>, f64> {
         let from = self.emit();
 
         self.update_state(action);
@@ -82,7 +83,7 @@ impl Domain for ContinuousMountainCar {
 
     fn is_terminal(&self) -> bool { self.x >= X_MAX }
 
-    fn reward(&self, _: &Observation<Vec<f64>>, to: &Observation<Vec<f64>>) -> f64 {
+    fn reward(&self, _: &Observation<Vector<f64>>, to: &Observation<Vector<f64>>) -> f64 {
         match *to {
             Observation::Terminal(_) => REWARD_GOAL,
             _ => REWARD_STEP,
@@ -90,10 +91,10 @@ impl Domain for ContinuousMountainCar {
     }
 
     fn state_space(&self) -> Self::StateSpace {
-        RegularSpace::empty() + Continuous::new(X_MIN, X_MAX) + Continuous::new(V_MIN, V_MAX)
+        LinearSpace::empty() + Interval::bounded(X_MIN, X_MAX) + Interval::bounded(V_MIN, V_MAX)
     }
 
-    fn action_space(&self) -> Continuous { Continuous::new(MIN_ACTION, MAX_ACTION) }
+    fn action_space(&self) -> Interval { Interval::bounded(MIN_ACTION, MAX_ACTION) }
 }
 
 #[cfg(test)]

--- a/src/domains/mountain_car/discrete.rs
+++ b/src/domains/mountain_car/discrete.rs
@@ -1,7 +1,9 @@
 use domains::{Domain, Observation, Transition};
 use geometry::{
-    dimensions::{Continuous, Discrete},
-    RegularSpace,
+    Vector,
+    continuous::Interval,
+    discrete::Ordinal,
+    product::LinearSpace,
 };
 
 const X_MIN: f64 = -1.2;
@@ -32,7 +34,7 @@ const ALL_ACTIONS: [f64; 3] = [-1.0, 0.0, 1.0];
 /// [^1]: See [https://en.wikipedia.org/wiki/Mountain_car_problem](https://en.wikipedia.org/wiki/Mountain_car_problem)
 ///
 /// # Technical details
-/// The **state** is represented by a `Vec` with components:
+/// The **state** is represented by a `Vector` with components:
 ///
 /// | Index | Name     | Min   | Max   |
 /// | ----- | -------- | ----- | ----- |
@@ -69,11 +71,11 @@ impl Default for MountainCar {
 }
 
 impl Domain for MountainCar {
-    type StateSpace = RegularSpace<Continuous>;
-    type ActionSpace = Discrete;
+    type StateSpace = LinearSpace<Interval>;
+    type ActionSpace = Ordinal;
 
-    fn emit(&self) -> Observation<Vec<f64>> {
-        let s = vec![self.x, self.v];
+    fn emit(&self) -> Observation<Vector<f64>> {
+        let s = Vector::from_vec(vec![self.x, self.v]);
 
         if self.is_terminal() {
             Observation::Terminal(s)
@@ -82,7 +84,7 @@ impl Domain for MountainCar {
         }
     }
 
-    fn step(&mut self, action: usize) -> Transition<Vec<f64>, usize> {
+    fn step(&mut self, action: usize) -> Transition<Vector<f64>, usize> {
         let from = self.emit();
 
         self.update_state(action);
@@ -99,7 +101,7 @@ impl Domain for MountainCar {
 
     fn is_terminal(&self) -> bool { self.x >= X_MAX }
 
-    fn reward(&self, _: &Observation<Vec<f64>>, to: &Observation<Vec<f64>>) -> f64 {
+    fn reward(&self, _: &Observation<Vector<f64>>, to: &Observation<Vector<f64>>) -> f64 {
         match *to {
             Observation::Terminal(_) => REWARD_GOAL,
             _ => REWARD_STEP,
@@ -107,10 +109,10 @@ impl Domain for MountainCar {
     }
 
     fn state_space(&self) -> Self::StateSpace {
-        RegularSpace::empty() + Continuous::new(X_MIN, X_MAX) + Continuous::new(V_MIN, V_MAX)
+        LinearSpace::empty() + Interval::bounded(X_MIN, X_MAX) + Interval::bounded(V_MIN, V_MAX)
     }
 
-    fn action_space(&self) -> Discrete { Discrete::new(3) }
+    fn action_space(&self) -> Ordinal { Ordinal::new(3) }
 }
 
 #[cfg(test)]

--- a/src/fa/mocking.rs
+++ b/src/fa/mocking.rs
@@ -21,20 +21,20 @@ impl MockQ {
     pub fn clear_output(&mut self) { self.output = None }
 }
 
-impl Approximator<Vec<f64>> for MockQ {
+impl Approximator<Vector<f64>> for MockQ {
     type Value = Vector<f64>;
 
-    fn evaluate(&self, s: &Vec<f64>) -> EvaluationResult<Vector<f64>> {
+    fn evaluate(&self, s: &Vector<f64>) -> EvaluationResult<Vector<f64>> {
         Ok(match self.output {
             Some(ref vector) => vector.clone(),
             None => s.clone().into(),
         })
     }
 
-    fn update(&mut self, _: &Vec<f64>, _: Vector<f64>) -> UpdateResult<()> { Ok(()) }
+    fn update(&mut self, _: &Vector<f64>, _: Vector<f64>) -> UpdateResult<()> { Ok(()) }
 }
 
-impl QFunction<Vec<f64>> for MockQ {
+impl QFunction<Vector<f64>> for MockQ {
     fn n_actions(&self) -> usize {
         match self.output {
             Some(ref vector) => vector.len(),

--- a/src/policies/fixed/boltzmann.rs
+++ b/src/policies/fixed/boltzmann.rs
@@ -74,7 +74,7 @@ mod tests {
     fn test_0d() {
         let mut p = Boltzmann::new(MockQ::new_shared(None), 1.0);
 
-        p.sample(&vec![]);
+        p.sample(&vec![].into());
     }
 
     #[test]
@@ -82,7 +82,7 @@ mod tests {
         let mut p = Boltzmann::new(MockQ::new_shared(None), 1.0);
 
         for i in 1..100 {
-            assert_eq!(p.sample(&vec![i as f64]), 0);
+            assert_eq!(p.sample(&vec![i as f64].into()), 0);
         }
     }
 
@@ -92,7 +92,7 @@ mod tests {
         let mut counts = Vector::from_vec(vec![0.0, 0.0]);
 
         for _ in 0..50000 {
-            counts[p.sample(&vec![0.0, 1.0])] += 1.0;
+            counts[p.sample(&vec![0.0, 1.0].into())] += 1.0;
         }
 
         assert!((counts / 50000.0).all_close(
@@ -105,11 +105,11 @@ mod tests {
     fn test_probabilites() {
         let mut p = Boltzmann::new(MockQ::new_shared(None), 1.0);
 
-        assert!(&p.probabilities(&vec![0.0, 1.0]).all_close(
+        assert!(&p.probabilities(&vec![0.0, 1.0].into()).all_close(
             &Vector::from_vec(vec![1.0 / (1.0 + E), E / (1.0 + E)]),
             1e-6,
         ));
-        assert!(p.probabilities(&vec![0.0, 2.0],).all_close(
+        assert!(p.probabilities(&vec![0.0, 2.0].into()).all_close(
             &Vector::from_vec(vec![1.0 / (1.0 + E * E), E * E / (1.0 + E * E)]),
             1e-6,
         ));

--- a/src/policies/fixed/epsilon_greedy.rs
+++ b/src/policies/fixed/epsilon_greedy.rs
@@ -71,7 +71,7 @@ mod tests {
 
         q.borrow_mut().clear_output();
 
-        let qs = vec![1.0, 0.0];
+        let qs = vec![1.0, 0.0].into();
 
         let mut n0: f64 = 0.0;
         let mut n1: f64 = 0.0;
@@ -91,24 +91,24 @@ mod tests {
         let mut p = EpsilonGreedy::new(MockQ::new_shared(None), 0.5);
 
         assert!(
-            p.probabilities(&vec![1.0, 0.0, 0.0, 0.0, 0.0])
+            p.probabilities(&vec![1.0, 0.0, 0.0, 0.0, 0.0].into())
                 .all_close(&vec![0.6, 0.1, 0.1, 0.1, 0.1].into(), 1e-6)
         );
 
         assert!(
-            p.probabilities(&vec![0.0, 0.0, 0.0, 0.0, 1.0])
+            p.probabilities(&vec![0.0, 0.0, 0.0, 0.0, 1.0].into())
                 .all_close(&vec![0.1, 0.1, 0.1, 0.1, 0.6].into(), 1e-6)
         );
 
         assert!(
-            p.probabilities(&vec![1.0, 0.0, 0.0, 0.0, 1.0])
+            p.probabilities(&vec![1.0, 0.0, 0.0, 0.0, 1.0].into())
                 .all_close(&vec![0.35, 0.1, 0.1, 0.1, 0.35].into(), 1e-6)
         );
 
         let mut p = EpsilonGreedy::new(MockQ::new_shared(None), 1.0);
 
         assert!(
-            p.probabilities(&vec![-1.0, 0.0, 0.0, 0.0])
+            p.probabilities(&vec![-1.0, 0.0, 0.0, 0.0].into())
                 .all_close(&vec![0.25, 0.25, 0.25, 0.25].into(), 1e-6)
         );
     }

--- a/src/policies/fixed/greedy.rs
+++ b/src/policies/fixed/greedy.rs
@@ -56,55 +56,55 @@ mod tests {
     fn test_0d() {
         let mut p = Greedy::new(MockQ::new_shared(None));
 
-        p.sample(&vec![]);
+        p.sample(&vec![].into());
     }
 
     #[test]
     fn test_1d() {
         let mut p = Greedy::new(MockQ::new_shared(None));
 
-        assert!(p.sample(&vec![1.0]) == 0);
-        assert!(p.sample(&vec![-100.0]) == 0);
+        assert!(p.sample(&vec![1.0].into()) == 0);
+        assert!(p.sample(&vec![-100.0].into()) == 0);
     }
 
     #[test]
     fn test_two_positive() {
         let mut p = Greedy::new(MockQ::new_shared(None));
 
-        assert!(p.sample(&vec![10.0, 1.0]) == 0);
-        assert!(p.sample(&vec![1.0, 10.0]) == 1);
+        assert!(p.sample(&vec![10.0, 1.0].into()) == 0);
+        assert!(p.sample(&vec![1.0, 10.0].into()) == 1);
     }
 
     #[test]
     fn test_two_negative() {
         let mut p = Greedy::new(MockQ::new_shared(None));
 
-        assert!(p.sample(&vec![-10.0, -1.0]) == 1);
-        assert!(p.sample(&vec![-1.0, -10.0]) == 0);
+        assert!(p.sample(&vec![-10.0, -1.0].into()) == 1);
+        assert!(p.sample(&vec![-1.0, -10.0].into()) == 0);
     }
 
     #[test]
     fn test_two_alt() {
         let mut p = Greedy::new(MockQ::new_shared(None));
 
-        assert!(p.sample(&vec![10.0, -1.0]) == 0);
-        assert!(p.sample(&vec![-10.0, 1.0]) == 1);
-        assert!(p.sample(&vec![1.0, -10.0]) == 0);
-        assert!(p.sample(&vec![-1.0, 10.0]) == 1);
+        assert!(p.sample(&vec![10.0, -1.0].into()) == 0);
+        assert!(p.sample(&vec![-10.0, 1.0].into()) == 1);
+        assert!(p.sample(&vec![1.0, -10.0].into()) == 0);
+        assert!(p.sample(&vec![-1.0, 10.0].into()) == 1);
     }
 
     #[test]
     fn test_long() {
         let mut p = Greedy::new(MockQ::new_shared(None));
 
-        assert!(p.sample(&vec![-123.1, 123.1, 250.5, -1240.0, -4500.0, 10000.0, 20.1]) == 5);
+        assert!(p.sample(&vec![-123.1, 123.1, 250.5, -1240.0, -4500.0, 10000.0, 20.1].into()) == 5);
     }
 
     #[test]
     fn test_precision() {
         let mut p = Greedy::new(MockQ::new_shared(None));
 
-        assert!(p.sample(&vec![1e-7, 2e-7]) == 1);
+        assert!(p.sample(&vec![1e-7, 2e-7].into()) == 1);
     }
 
     #[test]
@@ -112,12 +112,12 @@ mod tests {
         let mut p = Greedy::new(MockQ::new_shared(None));
 
         assert_eq!(
-            p.probabilities(&vec![1e-7, 2e-7, 3e-7, 4e-7]),
+            p.probabilities(&vec![1e-7, 2e-7, 3e-7, 4e-7].into()),
             Vector::from_vec(vec![0.0, 0.0, 0.0, 1.0])
         );
 
         assert_eq!(
-            p.probabilities(&vec![1e-7, 1e-7, 1e-7, 1e-7]),
+            p.probabilities(&vec![1e-7, 1e-7, 1e-7, 1e-7].into()),
             Vector::from_vec(vec![0.25, 0.25, 0.25, 0.25])
         );
     }

--- a/src/prediction/gtd/gtd2.rs
+++ b/src/prediction/gtd/gtd2.rs
@@ -38,27 +38,44 @@ impl<S: ?Sized, P: Projector<S>> GTD2<S, P> {
             gamma: gamma.into(),
         }
     }
+
+    #[inline(always)]
+    fn update_theta(&mut self, phi_s: Projection, phi_ns: Projection, td_estimate: f64) {
+        let dim = self.fa_theta.projector.dim();
+        let phi = phi_s.expanded(dim) - self.gamma.value() * phi_ns.expanded(dim);
+
+        self.fa_theta.update_phi(&Projection::Dense(phi), self.alpha * td_estimate);
+    }
+
+    #[inline(always)]
+    fn update_w(&mut self, phi_s: Projection, error: f64) {
+        self.fa_w.update_phi(&phi_s, self.beta * error);
+    }
 }
 
 impl<S, A, M: Projector<S>> Algorithm<S, A> for GTD2<S, M> {
-    fn handle_sample(&mut self, sample: &Transition<S, A>) {
-        let phi_s = self.fa_theta.projector.project(&sample.from.state());
-        let phi_ns = self.fa_theta.projector.project(&sample.to.state());
+    fn handle_sample(&mut self, t: &Transition<S, A>) {
+        let phi_s = self.fa_theta.projector.project(&t.from.state());
+        let phi_ns = self.fa_theta.projector.project(&t.to.state());
 
-        let td_error = sample.reward + self.gamma * self.fa_theta.evaluate_phi(&phi_ns)
+        let td_error = t.reward + self.gamma * self.fa_theta.evaluate_phi(&phi_ns)
             - self.fa_theta.evaluate_phi(&phi_s);
         let td_estimate = self.fa_w.evaluate_phi(&phi_s);
 
-        let dim = self.fa_theta.projector.dim();
-        let update = phi_s.clone().expanded(dim) - self.gamma.value() * phi_ns.expanded(dim);
-
-        self.fa_w
-            .update_phi(&phi_s, self.beta * (td_error - td_estimate));
-        self.fa_theta
-            .update_phi(&Projection::Dense(update), self.alpha * td_estimate);
+        self.update_theta(phi_s.clone(), phi_ns, td_estimate);
+        self.update_w(phi_s, td_error - td_estimate);
     }
 
-    fn handle_terminal(&mut self, _: &Transition<S, A>) {
+    fn handle_terminal(&mut self, t: &Transition<S, A>) {
+        let phi_s = self.fa_theta.projector.project(&t.from.state());
+        let phi_ns = self.fa_theta.projector.project(&t.to.state());
+
+        let td_error = t.reward - self.fa_theta.evaluate_phi(&phi_s);
+        let td_estimate = self.fa_w.evaluate_phi(&phi_s);
+
+        self.update_theta(phi_s.clone(), phi_ns, td_estimate);
+        self.update_w(phi_s, td_error - td_estimate);
+
         self.alpha = self.alpha.step();
         self.beta = self.alpha.step();
         self.gamma = self.gamma.step();

--- a/src/prediction/gtd/tdc.rs
+++ b/src/prediction/gtd/tdc.rs
@@ -52,8 +52,8 @@ impl<S: ?Sized, P: Projector<S>> TDC<S, P> {
     }
 
     #[inline(always)]
-    fn update_w(&mut self, phi_s: Projection, error: f64) {
-        self.fa_w.update_phi(&phi_s, self.beta * error);
+    fn update_w(&mut self, phi_s: &Projection, error: f64) {
+        self.fa_w.update_phi(phi_s, self.beta * error);
     }
 }
 
@@ -66,19 +66,21 @@ impl<S, A, M: Projector<S>> Algorithm<S, A> for TDC<S, M> {
             - self.fa_theta.evaluate_phi(&phi_s);
         let td_estimate = self.fa_w.evaluate_phi(&phi_s);
 
-        self.update_w(phi_s.clone(), td_error - td_estimate);
+        self.update_w(&phi_s, td_error - td_estimate);
         self.update_theta(phi_s, phi_ns, td_error, td_estimate);
     }
 
     fn handle_terminal(&mut self, t: &Transition<S, A>) {
-        let phi_s = self.fa_theta.projector.project(&t.from.state());
-        let phi_ns = self.fa_theta.projector.project(&t.to.state());
+        {
+            let phi_s = self.fa_theta.projector.project(&t.from.state());
+            let phi_ns = self.fa_theta.projector.project(&t.to.state());
 
-        let td_error = t.reward - self.fa_theta.evaluate_phi(&phi_s);
-        let td_estimate = self.fa_w.evaluate_phi(&phi_s);
+            let td_error = t.reward - self.fa_theta.evaluate_phi(&phi_s);
+            let td_estimate = self.fa_w.evaluate_phi(&phi_s);
 
-        self.update_w(phi_s.clone(), td_error - td_estimate);
-        self.update_theta(phi_s, phi_ns, td_error, td_estimate);
+            self.update_w(&phi_s, td_error - td_estimate);
+            self.update_theta(phi_s, phi_ns, td_error, td_estimate);
+        }
 
         self.alpha = self.alpha.step();
         self.beta = self.alpha.step();

--- a/src/prediction/mc/gradient_mc.rs
+++ b/src/prediction/mc/gradient_mc.rs
@@ -4,7 +4,7 @@ use fa::{Parameterised, VFunction};
 use geometry::Matrix;
 use std::marker::PhantomData;
 
-pub struct EveryVisitMC<S, V: VFunction<S>> {
+pub struct GradientMC<S, V: VFunction<S>> {
     pub v_func: V,
     pub cache: Vec<(S, f64)>,
 
@@ -14,13 +14,13 @@ pub struct EveryVisitMC<S, V: VFunction<S>> {
     phantom: PhantomData<S>,
 }
 
-impl<S, V: VFunction<S>> EveryVisitMC<S, V> {
+impl<S, V: VFunction<S>> GradientMC<S, V> {
     pub fn new<T1, T2>(v_func: V, alpha: T1, gamma: T2) -> Self
     where
         T1: Into<Parameter>,
         T2: Into<Parameter>,
     {
-        EveryVisitMC {
+        GradientMC {
             v_func,
             cache: vec![],
 
@@ -43,7 +43,7 @@ impl<S, V: VFunction<S>> EveryVisitMC<S, V> {
     }
 }
 
-impl<S: Clone, A, V: VFunction<S>> Algorithm<S, A> for EveryVisitMC<S, V> {
+impl<S: Clone, A, V: VFunction<S>> Algorithm<S, A> for GradientMC<S, V> {
     fn handle_sample(&mut self, sample: &Transition<S, A>) {
         self.cache.push((sample.from.state().clone(), sample.reward));
     }
@@ -56,11 +56,11 @@ impl<S: Clone, A, V: VFunction<S>> Algorithm<S, A> for EveryVisitMC<S, V> {
     }
 }
 
-impl<S: Clone, A, V: VFunction<S>> Predictor<S, A> for EveryVisitMC<S, V> {
+impl<S: Clone, A, V: VFunction<S>> Predictor<S, A> for GradientMC<S, V> {
     fn predict_v(&mut self, s: &S) -> f64 { self.v_func.evaluate(s).unwrap() }
 }
 
-impl<S, V: VFunction<S> + Parameterised> Parameterised for EveryVisitMC<S, V> {
+impl<S, V: VFunction<S> + Parameterised> Parameterised for GradientMC<S, V> {
     fn weights(&self) -> Matrix<f64> {
         self.v_func.weights()
     }

--- a/src/prediction/mc/gradient_mc.rs
+++ b/src/prediction/mc/gradient_mc.rs
@@ -49,7 +49,9 @@ impl<S: Clone, A, V: VFunction<S>> Algorithm<S, A> for GradientMC<S, V> {
     }
 
     fn handle_terminal(&mut self, _: &Transition<S, A>) {
-        self.propagate();
+        {
+            self.propagate();
+        }
 
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();

--- a/src/prediction/mc/mod.rs
+++ b/src/prediction/mc/mod.rs
@@ -1,1 +1,1 @@
-import_all!(every_visit_mc);
+import_all!(gradient_mc);

--- a/src/prediction/td/mod.rs
+++ b/src/prediction/td/mod.rs
@@ -2,6 +2,7 @@ import_all!(td);
 import_all!(td_lambda);
 
 // TODO:
+// n-step TD - Sutton & Barto
 // ETD(lambda) - https://arxiv.org/pdf/1503.04269.pdf
 // HTD(lambda) - https://arxiv.org/pdf/1602.08771.pdf
 // PTD(lambda) - http://proceedings.mlr.press/v32/sutton14.pdf

--- a/src/prediction/td/td.rs
+++ b/src/prediction/td/td.rs
@@ -28,21 +28,33 @@ impl<S: ?Sized, V: VFunction<S>> TD<S, V> {
             phantom: PhantomData,
         }
     }
+
+    #[inline(always)]
+    fn update_v(&mut self, s: &S, error: f64) {
+        let _ = self.v_func.update(s, self.alpha * error);
+    }
 }
 
 impl<S, A, V: VFunction<S>> Algorithm<S, A> for TD<S, V>
 where
     Self: Predictor<S, A>
 {
-    fn handle_sample(&mut self, sample: &Transition<S, A>) {
-        let v = self.predict_v(&sample.from.state());
-        let nv = self.predict_v(&sample.to.state());
+    fn handle_sample(&mut self, t: &Transition<S, A>) {
+        let s = t.from.state();
+        let v = self.predict_v(&s);
+        let nv = self.predict_v(&t.to.state());
 
-        let td_error = sample.reward + self.gamma * nv - v;
-        let _ = self.v_func.update(&sample.from.state(), self.alpha * td_error);
+        let td_error = t.reward + self.gamma * nv - v;
+
+        self.update_v(&s, td_error);
     }
 
-    fn handle_terminal(&mut self, _: &Transition<S, A>) {
+    fn handle_terminal(&mut self, t: &Transition<S, A>) {
+        let s = t.from.state();
+        let td_error = t.reward - self.predict_v(&t.from.state());
+
+        self.update_v(&s, td_error);
+
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
     }

--- a/src/prediction/td/td.rs
+++ b/src/prediction/td/td.rs
@@ -50,10 +50,12 @@ where
     }
 
     fn handle_terminal(&mut self, t: &Transition<S, A>) {
-        let s = t.from.state();
-        let td_error = t.reward - self.predict_v(&t.from.state());
+        {
+            let s = t.from.state();
+            let td_error = t.reward - self.predict_v(&t.from.state());
 
-        self.update_v(&s, td_error);
+            self.update_v(&s, td_error);
+        }
 
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();

--- a/src/prediction/td/td_lambda.rs
+++ b/src/prediction/td/td_lambda.rs
@@ -57,15 +57,17 @@ where
     }
 
     fn handle_terminal(&mut self, t: &Transition<S, A>) {
-        let phi_s = self.fa_theta.projector.project(&t.from.state());
-        let td_error = t.reward - self.fa_theta.evaluate_phi(&phi_s);
+        {
+            let phi_s = self.fa_theta.projector.project(&t.from.state());
+            let td_error = t.reward - self.fa_theta.evaluate_phi(&phi_s);
 
-        self.update_v(phi_s, td_error);
+            self.update_v(phi_s, td_error);
+
+            self.trace.decay(0.0);
+        }
 
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
-
-        self.trace.decay(0.0);
     }
 }
 


### PR DESCRIPTION
After extensive testing of the prediction algorithms available in `rsrl`, I discovered some edge cases where the value function approximation diverged. This turned out to be an issue in and old, hacky part of the codebase which wasn't using `handle_sample` and `handle_terminal` correctly. To fix this, we've added the correct terminal state algorithm logic to all the algos and made sure experiments are run correctly.

This PR doesn't add any new functionality, but definitely prevents some divergence cases and makes the framework more robust (and correct!).