### PR TITLE
Type parameter cull

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ openai = ["cpython"]
 
 [dependencies]
 spaces = "4.1"
-lfa = "0.6"
+lfa = "0.8"
 
 rand = "0.6"
 cpython = { version = "0.2", optional = true }

--- a/examples/greedy_gq.rs
+++ b/examples/greedy_gq.rs
@@ -9,7 +9,7 @@ use rsrl::{
     fa::{basis::fixed::Fourier, LFA},
     geometry::Space,
     logging,
-    policies::fixed::EpsilonGreedy,
+    policies::fixed::{Greedy, Random, EpsilonGreedy},
 };
 
 fn main() {
@@ -21,12 +21,15 @@ fn main() {
 
         // Build the linear value functions using a fourier basis projection.
         let bases = Fourier::from_space(3, domain.state_space());
-        let v_func = make_shared(LFA::scalar_valued(bases.clone()));
-        let q_func = make_shared(LFA::vector_valued(bases, n_actions));
+        let v_func = make_shared(LFA::scalar_output(bases.clone()));
+        let q_func = make_shared(LFA::vector_output(bases, n_actions));
 
         // Build a stochastic behaviour policy with exponential epsilon.
-        let eps = Parameter::exponential(0.3, 0.001, 0.99);
-        let policy = make_shared(EpsilonGreedy::new(q_func.clone(), eps));
+        let policy = make_shared(EpsilonGreedy::new(
+            Greedy::new(q_func.clone()),
+            Random::new(n_actions),
+            Parameter::exponential(0.3, 0.001, 0.99),
+        ));
 
         GreedyGQ::new(q_func, v_func, policy, 1e-3, 1e-4, 0.99)
     };

--- a/examples/nac.rs
+++ b/examples/nac.rs
@@ -22,7 +22,7 @@ fn main() {
     let policy = make_shared({
         // Build the linear value function using a fourier basis projection and the
         // appropriate eligibility trace.
-        let fa = LFA::vector_valued(bases.clone(), n_actions);
+        let fa = LFA::vector_output(bases.clone(), n_actions);
 
         // Build a stochastic behaviour policy with exponential epsilon.
         Gibbs::new(fa)
@@ -30,7 +30,7 @@ fn main() {
     let critic = make_shared({
         // Build the linear value function using a fourier basis projection and the
         // appropriate eligibility trace.
-        let q_func = make_shared(LFA::vector_valued(bases, n_actions));
+        let q_func = make_shared(LFA::vector_output(bases, n_actions));
 
         SARSA::new(q_func, policy.clone(), 0.001, 0.99)
     });

--- a/examples/pal.rs
+++ b/examples/pal.rs
@@ -9,7 +9,7 @@ use rsrl::{
     fa::{basis::fixed::Fourier, LFA},
     geometry::Space,
     logging,
-    policies::fixed::EpsilonGreedy,
+    policies::fixed::{Greedy, Random, EpsilonGreedy},
 };
 
 fn main() {
@@ -20,13 +20,16 @@ fn main() {
         // Build the linear value function using a fourier basis projection and the
         // appropriate eligibility trace.
         let bases = Fourier::from_space(3, domain.state_space());
-        let q_func = make_shared(LFA::vector_valued(bases, n_actions));
+        let q_func = make_shared(LFA::vector_output(bases, n_actions));
 
         // Build a stochastic behaviour policy with exponential epsilon.
-        let eps = Parameter::exponential(0.99, 0.05, 0.99);
-        let policy = make_shared(EpsilonGreedy::new(q_func.clone(), eps));
+        let policy = make_shared(EpsilonGreedy::new(
+            Greedy::new(q_func.clone()),
+            Random::new(n_actions),
+            Parameter::exponential(0.7, 0.01, 0.9),
+        ));
 
-        PAL::new(q_func, policy, 0.1, 0.99)
+        PAL::new(q_func, policy, 0.01, 0.99)
     };
 
     let logger = logging::root(logging::stdout());

--- a/examples/polynomial.rs
+++ b/examples/polynomial.rs
@@ -9,7 +9,7 @@ use rsrl::{
     fa::{basis::fixed::Chebyshev, LFA},
     geometry::Space,
     logging,
-    policies::fixed::EpsilonGreedy,
+    policies::fixed::{Greedy, Random, EpsilonGreedy},
 };
 
 fn main() {
@@ -21,11 +21,14 @@ fn main() {
         // appropriate eligibility trace.
         let bases = Chebyshev::from_space(5, domain.state_space());
         let trace = Trace::replacing(0.7, bases.dim());
-        let q_func = make_shared(LFA::vector_valued(bases, n_actions));
+        let q_func = make_shared(LFA::vector_output(bases, n_actions));
 
         // Build a stochastic behaviour policy with exponential epsilon.
-        let eps = Parameter::exponential(0.99, 0.05, 0.99);
-        let policy = make_shared(EpsilonGreedy::new(q_func.clone(), eps));
+        let policy = make_shared(EpsilonGreedy::new(
+            Greedy::new(q_func.clone()),
+            Random::new(n_actions),
+            Parameter::exponential(0.5, 0.001, 0.9),
+        ));
 
         SARSALambda::new(q_func, policy, trace, 0.001, 0.99)
     };

--- a/examples/sarsa_lambda.rs
+++ b/examples/sarsa_lambda.rs
@@ -9,7 +9,7 @@ use rsrl::{
     fa::{basis::fixed::Fourier, LFA},
     geometry::Space,
     logging,
-    policies::fixed::EpsilonGreedy,
+    policies::fixed::{Greedy, Random, EpsilonGreedy},
 };
 
 fn main() {
@@ -21,11 +21,14 @@ fn main() {
         // appropriate eligibility trace.
         let bases = Fourier::from_space(3, domain.state_space());
         let trace = Trace::replacing(0.7, bases.dim());
-        let q_func = make_shared(LFA::vector_valued(bases, n_actions));
+        let q_func = make_shared(LFA::vector_output(bases, n_actions));
 
         // Build a stochastic behaviour policy with exponential epsilon.
-        let eps = Parameter::exponential(0.5, 0.001, 0.9);
-        let policy = make_shared(EpsilonGreedy::new(q_func.clone(), eps));
+        let policy = make_shared(EpsilonGreedy::new(
+            Greedy::new(q_func.clone()),
+            Random::new(n_actions),
+            Parameter::exponential(0.5, 0.001, 0.9),
+        ));
 
         SARSALambda::new(q_func, policy, trace, 0.001, 0.99)
     };

--- a/src/control/actor_critic/tdac.rs
+++ b/src/control/actor_critic/tdac.rs
@@ -4,21 +4,19 @@ use crate::policies::{Policy, ParameterisedPolicy};
 use std::marker::PhantomData;
 
 /// TD-error actor-critic.
-pub struct TDAC<S, C, P> {
+pub struct TDAC<C, P> {
     pub critic: Shared<C>,
     pub policy: Shared<P>,
 
     pub alpha: Parameter,
     pub gamma: Parameter,
-
-    phantom: PhantomData<S>,
 }
 
-impl<S, C, P> TDAC<S, C, P> {
+impl<C, P> TDAC<C, P> {
     pub fn new<T1, T2>(critic: Shared<C>, policy: Shared<P>, alpha: T1, gamma: T2) -> Self
-        where
-            T1: Into<Parameter>,
-            T2: Into<Parameter>,
+    where
+        T1: Into<Parameter>,
+        T2: Into<Parameter>,
     {
         TDAC {
             critic,
@@ -26,13 +24,11 @@ impl<S, C, P> TDAC<S, C, P> {
 
             alpha: alpha.into(),
             gamma: gamma.into(),
-
-            phantom: PhantomData,
         }
     }
 }
 
-impl<S, C, P> Algorithm for TDAC<S, C, P>
+impl<C, P> Algorithm for TDAC<C, P>
 where
     C: Algorithm,
     P: Algorithm,
@@ -46,49 +42,39 @@ where
     }
 }
 
-impl<S, C, P> TDAC<S, C, P>
-where
-    C: ValuePredictor<S>,
-    P: ParameterisedPolicy<S>,
-    P::Action: Clone,
-{
-    fn update_policy(&mut self, t: &Transition<S, P::Action>) {
-        let (s, ns) = (t.from.state(), t.to.state());
-
-        let v = self.critic.borrow_mut().predict_v(s);
-        let nv = self.critic.borrow_mut().predict_v(ns);
-
-        let residual = if t.terminated() {
-            t.reward - v
-        } else {
-            t.reward + self.gamma * nv - v
-        };
-
-        self.policy.borrow_mut().update(s, t.action.clone(), self.alpha * residual);
-    }
-}
-
-impl<S, C, P> OnlineLearner<S, P::Action> for TDAC<S, C, P>
+impl<S, C, P> OnlineLearner<S, P::Action> for TDAC<C, P>
 where
     C: OnlineLearner<S, P::Action> + ValuePredictor<S>,
     P: ParameterisedPolicy<S>,
     P::Action: Clone,
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
+        let (s, ns) = (t.from.state(), t.to.state());
+
+        let v = self.critic.borrow_mut().predict_v(s);
+        let nv = self.critic.borrow_mut().predict_v(ns);
+        let residual = t.reward + self.gamma * nv - v;
+
         self.critic.borrow_mut().handle_transition(t);
-        self.update_policy(t);
+        self.policy.borrow_mut().update(s, t.action.clone(), self.alpha * residual);
     }
 
-    fn handle_sequence(&mut self, sequence: &[Transition<S, P::Action>]) {
-        self.critic.borrow_mut().handle_sequence(sequence);
+    fn handle_sequence(&mut self, seq: &[Transition<S, P::Action>]) {
+        self.critic.borrow_mut().handle_sequence(seq);
 
-        sequence.into_iter().for_each(|ref t| {
-            self.update_policy(t);
-        });
+        for t in seq {
+            let (s, ns) = (t.from.state(), t.to.state());
+
+            let v = self.critic.borrow_mut().predict_v(s);
+            let nv = self.critic.borrow_mut().predict_v(ns);
+            let residual = t.reward + self.gamma * nv - v;
+
+            self.policy.borrow_mut().update(s, t.action.clone(), self.alpha * residual);
+        }
     }
 }
 
-impl<S, C, P> ValuePredictor<S> for TDAC<S, C, P>
+impl<S, C, P> ValuePredictor<S> for TDAC<C, P>
 where
     C: ValuePredictor<S>,
 {
@@ -97,7 +83,7 @@ where
     }
 }
 
-impl<S, C, P> ActionValuePredictor<S, P::Action> for TDAC<S, C, P>
+impl<S, C, P> ActionValuePredictor<S, P::Action> for TDAC<C, P>
 where
     C: ActionValuePredictor<S, P::Action>,
     P: Policy<S>,
@@ -111,7 +97,7 @@ where
     }
 }
 
-impl<S, C, P> Controller<S, P::Action> for TDAC<S, C, P>
+impl<S, C, P> Controller<S, P::Action> for TDAC<C, P>
 where
     P: ParameterisedPolicy<S>,
 {

--- a/src/control/gtd/greedy_gq.rs
+++ b/src/control/gtd/greedy_gq.rs
@@ -62,8 +62,7 @@ where
     P: Policy<S, Action = <Greedy<VectorLFA<M>> as Policy<S>>::Action>,
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
-        let (s, ns) = (t.from.state(), t.to.state());
-
+        let s = t.from.state();
         let dim = self.fa_theta.borrow().projector.dim();
         let phi_s = self.fa_w.borrow().projector.project(s);
 
@@ -82,6 +81,7 @@ where
                 self.alpha.value() * residual
             );
         } else {
+            let ns = t.from.state();
             let na = self.sample_target(ns);
             let phi_ns = self.fa_w.borrow().projector.project(ns);
 

--- a/src/control/mc/reinforce.rs
+++ b/src/control/mc/reinforce.rs
@@ -5,16 +5,14 @@ use crate::fa::Parameterised;
 use crate::policies::{Policy, ParameterisedPolicy};
 use std::marker::PhantomData;
 
-pub struct REINFORCE<S, P> {
+pub struct REINFORCE<P> {
     pub policy: Shared<P>,
 
     pub alpha: Parameter,
     pub gamma: Parameter,
-
-    phantom: PhantomData<S>,
 }
 
-impl<S, P> REINFORCE<S, P> {
+impl<P> REINFORCE<P> {
     pub fn new<T1, T2>(policy: Shared<P>, alpha: T1, gamma: T2) -> Self
     where
         T1: Into<Parameter>,
@@ -25,13 +23,11 @@ impl<S, P> REINFORCE<S, P> {
 
             alpha: alpha.into(),
             gamma: gamma.into(),
-
-            phantom: PhantomData,
         }
     }
 }
 
-impl<S, P: Algorithm> Algorithm for REINFORCE<S, P> {
+impl<P: Algorithm> Algorithm for REINFORCE<P> {
     fn handle_terminal(&mut self) {
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
@@ -40,35 +36,34 @@ impl<S, P: Algorithm> Algorithm for REINFORCE<S, P> {
     }
 }
 
-impl<S, P> BatchLearner<S, P::Action> for REINFORCE<S, P>
+impl<S, P> BatchLearner<S, P::Action> for REINFORCE<P>
 where
     P: ParameterisedPolicy<S>,
     P::Action: Clone,
 {
     fn handle_batch(&mut self, batch: &[Transition<S, P::Action>]) {
+        let z = batch.len() as f64;
         let mut ret = 0.0;
 
         for t in batch.into_iter().rev() {
             ret = t.reward + self.gamma * ret;
 
-            self.policy.borrow_mut().update(t.from.state(), t.action.clone(), self.alpha * ret);
+            self.policy.borrow_mut().update(
+                t.from.state(),
+                t.action.clone(),
+                self.alpha * ret / z
+            );
         }
     }
 }
 
-impl<S, P> Controller<S, P::Action> for REINFORCE<S, P>
-where
-    P: ParameterisedPolicy<S>,
-{
+impl<S, P: ParameterisedPolicy<S>> Controller<S, P::Action> for REINFORCE<P> {
     fn sample_target(&mut self, s: &S) -> P::Action { self.policy.borrow_mut().sample(s) }
 
     fn sample_behaviour(&mut self, s: &S) -> P::Action { self.policy.borrow_mut().sample(s) }
 }
 
-impl<S, P> Parameterised for REINFORCE<S, P>
-where
-    P: Parameterised,
-{
+impl<P: Parameterised> Parameterised for REINFORCE<P> {
     fn weights(&self) -> Matrix<f64> {
         self.policy.borrow().weights()
     }

--- a/src/control/td/expected_sarsa.rs
+++ b/src/control/td/expected_sarsa.rs
@@ -52,12 +52,12 @@ where
     P: FinitePolicy<S>,
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
-        let (s, ns) = (t.from.state(), t.to.state());
-
+        let s = t.from.state();
         let qsa = self.predict_qsa(s, t.action);
         let residual = if t.terminated() {
             t.reward - qsa
         } else {
+            let ns = t.to.state();
             let exp_nv = self.predict_v(ns);
 
             t.reward + self.gamma * exp_nv - qsa

--- a/src/control/td/expected_sarsa.rs
+++ b/src/control/td/expected_sarsa.rs
@@ -13,17 +13,15 @@ use std::marker::PhantomData;
 /// theoretical and empirical analysis of Expected Sarsa. In Proceedings of the
 /// IEEE Symposium on Adaptive Dynamic Programming and Reinforcement Learning,
 /// pp. 177–184.
-pub struct ExpectedSARSA<S, Q, P> {
+pub struct ExpectedSARSA<Q, P> {
     pub q_func: Shared<Q>,
     pub policy: Shared<P>,
 
     pub alpha: Parameter,
     pub gamma: Parameter,
-
-    phantom: PhantomData<S>,
 }
 
-impl<S, Q, P> ExpectedSARSA<S, Q, P> {
+impl<Q, P> ExpectedSARSA<Q, P> {
     pub fn new<T1, T2>(q_func: Shared<Q>, policy: Shared<P>, alpha: T1, gamma: T2) -> Self
     where
         T1: Into<Parameter>,
@@ -35,13 +33,11 @@ impl<S, Q, P> ExpectedSARSA<S, Q, P> {
 
             alpha: alpha.into(),
             gamma: gamma.into(),
-
-            phantom: PhantomData,
         }
     }
 }
 
-impl<S, Q, P: Algorithm> Algorithm for ExpectedSARSA<S, Q, P> {
+impl<Q, P: Algorithm> Algorithm for ExpectedSARSA<Q, P> {
     fn handle_terminal(&mut self) {
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
@@ -50,7 +46,7 @@ impl<S, Q, P: Algorithm> Algorithm for ExpectedSARSA<S, Q, P> {
     }
 }
 
-impl<S, Q, P> OnlineLearner<S, P::Action> for ExpectedSARSA<S, Q, P>
+impl<S, Q, P> OnlineLearner<S, P::Action> for ExpectedSARSA<Q, P>
 where
     Q: QFunction<S>,
     P: FinitePolicy<S>,
@@ -71,16 +67,13 @@ where
     }
 }
 
-impl<S, Q, P> Controller<S, P::Action> for ExpectedSARSA<S, Q, P>
-where
-    P: Policy<S>,
-{
+impl<S, Q, P: Policy<S>> Controller<S, P::Action> for ExpectedSARSA<Q, P> {
     fn sample_target(&mut self, s: &S) -> P::Action { self.policy.borrow_mut().sample(s) }
 
     fn sample_behaviour(&mut self, s: &S) -> P::Action { self.policy.borrow_mut().sample(s) }
 }
 
-impl<S, Q, P> ValuePredictor<S> for ExpectedSARSA<S, Q, P>
+impl<S, Q, P> ValuePredictor<S> for ExpectedSARSA<Q, P>
 where
     Q: QFunction<S>,
     P: FinitePolicy<S>,
@@ -90,7 +83,7 @@ where
     }
 }
 
-impl<S, Q, P> ActionValuePredictor<S, P::Action> for ExpectedSARSA<S, Q, P>
+impl<S, Q, P> ActionValuePredictor<S, P::Action> for ExpectedSARSA<Q, P>
 where
     Q: QFunction<S>,
     P: FinitePolicy<S>,
@@ -104,10 +97,7 @@ where
     }
 }
 
-impl<S, Q, P> Parameterised for ExpectedSARSA<S, Q, P>
-where
-    Q: Parameterised,
-{
+impl<Q: Parameterised, P> Parameterised for ExpectedSARSA<Q, P> {
     fn weights(&self) -> Matrix<f64> {
         self.q_func.borrow().weights()
     }

--- a/src/control/td/pal.rs
+++ b/src/control/td/pal.rs
@@ -52,15 +52,14 @@ where
     P: Policy<S, Action = <Greedy<Q> as Policy<S>>::Action>,
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
-        let (s, ns) = (t.from.state(), t.to.state());
-
+        let s = t.from.state();
         let qs = self.predict_qs(s);
-
         let residual = if t.terminated() {
             t.reward - qs[t.action]
-
         } else {
+            let ns = t.to.state();
             let nqs = self.predict_qs(ns);
+
             let a_star = self.sample_target(s);
             let na_star = self.sample_target(ns);
 

--- a/src/control/td/pal.rs
+++ b/src/control/td/pal.rs
@@ -8,21 +8,17 @@ use crate::policies::{fixed::Greedy, Policy};
 /// # References
 /// - Bellemare, Marc G., et al. "Increasing the Action Gap: New Operators for
 /// Reinforcement Learning." AAAI. 2016.
-pub struct PAL<S, Q, P> {
+pub struct PAL<Q, P> {
     pub q_func: Shared<Q>,
 
     pub policy: Shared<P>,
-    pub target: Greedy<S>,
+    pub target: Greedy<Q>,
 
     pub alpha: Parameter,
     pub gamma: Parameter,
 }
 
-impl<S, Q, P> PAL<S, Q, P>
-where
-    Q: QFunction<S> + 'static,
-    P: Policy<S>,
-{
+impl<Q, P> PAL<Q, P> {
     pub fn new<T1, T2>(q_func: Shared<Q>, policy: Shared<P>, alpha: T1, gamma: T2) -> Self
     where
         T1: Into<Parameter>,
@@ -40,7 +36,7 @@ where
     }
 }
 
-impl<S, Q, P: Algorithm> Algorithm for PAL<S, Q, P> {
+impl<Q, P: Algorithm> Algorithm for PAL<Q, P> {
     fn handle_terminal(&mut self) {
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
@@ -50,10 +46,10 @@ impl<S, Q, P: Algorithm> Algorithm for PAL<S, Q, P> {
     }
 }
 
-impl<S, Q, P> OnlineLearner<S, P::Action> for PAL<S, Q, P>
+impl<S, Q, P> OnlineLearner<S, P::Action> for PAL<Q, P>
 where
     Q: QFunction<S>,
-    P: Policy<S, Action = <Greedy<S> as Policy<S>>::Action>,
+    P: Policy<S, Action = <Greedy<Q> as Policy<S>>::Action>,
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
         let (s, ns) = (t.from.state(), t.to.state());
@@ -78,19 +74,20 @@ where
     }
 }
 
-impl<S, Q, P> Controller<S, P::Action> for PAL<S, Q, P>
+impl<S, Q, P> Controller<S, P::Action> for PAL<Q, P>
 where
-    P: Policy<S, Action = <Greedy<S> as Policy<S>>::Action>,
+    Q: QFunction<S>,
+    P: Policy<S, Action = <Greedy<Q> as Policy<S>>::Action>,
 {
     fn sample_target(&mut self, s: &S) -> P::Action { self.target.sample(s) }
 
     fn sample_behaviour(&mut self, s: &S) -> P::Action { self.policy.borrow_mut().sample(s) }
 }
 
-impl<S, Q, P> ValuePredictor<S> for PAL<S, Q, P>
+impl<S, Q, P> ValuePredictor<S> for PAL<Q, P>
 where
     Q: QFunction<S>,
-    P: Policy<S, Action = <Greedy<S> as Policy<S>>::Action>,
+    P: Policy<S, Action = <Greedy<Q> as Policy<S>>::Action>,
 {
     fn predict_v(&mut self, s: &S) -> f64 {
         let a = self.target.sample(s);
@@ -99,10 +96,10 @@ where
     }
 }
 
-impl<S, Q, P> ActionValuePredictor<S, P::Action> for PAL<S, Q, P>
+impl<S, Q, P> ActionValuePredictor<S, P::Action> for PAL<Q, P>
 where
     Q: QFunction<S>,
-    P: Policy<S, Action = <Greedy<S> as Policy<S>>::Action>,
+    P: Policy<S, Action = <Greedy<Q> as Policy<S>>::Action>,
 {
     fn predict_qs(&mut self, s: &S) -> Vector<f64> {
         self.q_func.borrow().evaluate(s).unwrap()
@@ -113,10 +110,7 @@ where
     }
 }
 
-impl<S, Q, P> Parameterised for PAL<S, Q, P>
-where
-    Q: Parameterised,
-{
+impl<Q: Parameterised, P> Parameterised for PAL<Q, P> {
     fn weights(&self) -> Matrix<f64> {
         self.q_func.borrow().weights()
     }

--- a/src/control/td/q_lambda.rs
+++ b/src/control/td/q_lambda.rs
@@ -64,8 +64,7 @@ where
     P: Policy<S, Action = <Greedy<VectorLFA<M>> as Policy<S>>::Action>,
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
-        let (s, ns) = (t.from.state(), t.to.state());
-
+        let s = t.from.state();
         let phi_s = self.fa_theta.borrow().projector.project(s);
         let qsa = self.fa_theta.borrow().evaluate_action_phi(&phi_s, t.action);
 
@@ -87,6 +86,7 @@ where
 
             t.reward - qsa
         } else {
+            let ns = t.to.state();
             let na = self.target.sample(&ns);
             let nqsna = self.fa_theta.borrow().evaluate_action(ns, na);
 

--- a/src/control/td/q_learning.rs
+++ b/src/control/td/q_learning.rs
@@ -54,12 +54,12 @@ where
     P: Policy<S, Action = <Greedy<Q> as Policy<S>>::Action>,
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
-        let (s, ns) = (t.from.state(), t.to.state());
-
+        let s = t.from.state();
         let qsa = self.predict_qsa(&s, t.action);
         let residual = if t.terminated() {
             t.reward - qsa
         } else {
+            let ns = t.to.state();
             let na = self.sample_target(&ns);
             let nqsna = self.predict_qsa(&ns, na);
 

--- a/src/control/td/q_learning.rs
+++ b/src/control/td/q_learning.rs
@@ -11,22 +11,17 @@ use std::marker::PhantomData;
 /// Cambridge University.
 /// - Watkins, C. J. C. H., Dayan, P. (1992). Q-learning. Machine Learning,
 /// 8:279–292.
-pub struct QLearning<S, Q, P> {
+pub struct QLearning<Q, P> {
     pub q_func: Shared<Q>,
 
     pub policy: Shared<P>,
-    pub target: Greedy<S>,
+    pub target: Greedy<Q>,
 
     pub alpha: Parameter,
     pub gamma: Parameter,
-
-    phantom: PhantomData<S>,
 }
 
-impl<S, Q, P> QLearning<S, Q, P>
-where
-    Q: QFunction<S> + 'static,
-{
+impl<Q, P> QLearning<Q, P> {
     pub fn new<T1, T2>(q_func: Shared<Q>, policy: Shared<P>, alpha: T1, gamma: T2) -> Self
     where
         T1: Into<Parameter>,
@@ -40,13 +35,11 @@ where
 
             alpha: alpha.into(),
             gamma: gamma.into(),
-
-            phantom: PhantomData,
         }
     }
 }
 
-impl<S, Q, P: Algorithm> Algorithm for QLearning<S, Q, P> {
+impl<Q, P: Algorithm> Algorithm for QLearning<Q, P> {
     fn handle_terminal(&mut self) {
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
@@ -55,10 +48,10 @@ impl<S, Q, P: Algorithm> Algorithm for QLearning<S, Q, P> {
     }
 }
 
-impl<S, Q, P> OnlineLearner<S, P::Action> for QLearning<S, Q, P>
+impl<S, Q, P> OnlineLearner<S, P::Action> for QLearning<Q, P>
 where
     Q: QFunction<S>,
-    P: Policy<S, Action = <Greedy<S> as Policy<S>>::Action>,
+    P: Policy<S, Action = <Greedy<Q> as Policy<S>>::Action>,
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
         let (s, ns) = (t.from.state(), t.to.state());
@@ -77,19 +70,20 @@ where
     }
 }
 
-impl<S, Q, P> Controller<S, P::Action> for QLearning<S, Q, P>
+impl<S, Q, P> Controller<S, P::Action> for QLearning<Q, P>
 where
-    P: Policy<S, Action = <Greedy<S> as Policy<S>>::Action>,
+    Q: QFunction<S>,
+    P: Policy<S, Action = <Greedy<Q> as Policy<S>>::Action>,
 {
     fn sample_target(&mut self, s: &S) -> P::Action { self.target.sample(s) }
 
     fn sample_behaviour(&mut self, s: &S) -> P::Action { self.policy.borrow_mut().sample(s) }
 }
 
-impl<S, Q, P> ValuePredictor<S> for QLearning<S, Q, P>
+impl<S, Q, P> ValuePredictor<S> for QLearning<Q, P>
 where
     Q: QFunction<S>,
-    P: Policy<S, Action = <Greedy<S> as Policy<S>>::Action>,
+    P: Policy<S, Action = <Greedy<Q> as Policy<S>>::Action>,
 {
     fn predict_v(&mut self, s: &S) -> f64 {
         let a = self.target.sample(s);
@@ -98,10 +92,10 @@ where
     }
 }
 
-impl<S, Q, P> ActionValuePredictor<S, P::Action> for QLearning<S, Q, P>
+impl<S, Q, P> ActionValuePredictor<S, P::Action> for QLearning<Q, P>
 where
     Q: QFunction<S>,
-    P: Policy<S, Action = <Greedy<S> as Policy<S>>::Action>,
+    P: Policy<S, Action = <Greedy<Q> as Policy<S>>::Action>,
 {
     fn predict_qs(&mut self, s: &S) -> Vector<f64> {
         self.q_func.borrow().evaluate(s).unwrap()
@@ -112,10 +106,7 @@ where
     }
 }
 
-impl<S, Q, P> Parameterised for QLearning<S, Q, P>
-where
-    Q: Parameterised,
-{
+impl<Q: Parameterised, P> Parameterised for QLearning<Q, P> {
     fn weights(&self) -> Matrix<f64> {
         self.q_func.borrow().weights()
     }

--- a/src/control/td/q_sigma.rs
+++ b/src/control/td/q_sigma.rs
@@ -128,8 +128,7 @@ where
     P: Policy<S, Action = <Greedy<Q> as Policy<S>>::Action>,
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
-        let (s, ns) = (t.from.state(), t.to.state());
-
+        let s = t.from.state();
         let qa = self.predict_qsa(&s, t.action);
         let sigma = {
             self.sigma = self.sigma.step();
@@ -152,6 +151,7 @@ where
             self.backup.clear();
 
         } else {
+            let ns = t.to.state();
             let na = self.sample_behaviour(&ns);
             let nqs = self.q_func.borrow().evaluate(&ns).unwrap();
             let nqa = nqs[na];

--- a/src/control/td/sarsa.rs
+++ b/src/control/td/sarsa.rs
@@ -50,12 +50,12 @@ where
     P: FinitePolicy<S>,
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
-        let (s, ns) = (t.from.state(), t.to.state());
-
+        let s = t.from.state();
         let qsa = self.q_func.borrow().evaluate_action(s, t.action);
         let residual = if t.terminated() {
             t.reward - qsa
         } else {
+            let ns = t.to.state();
             let na = self.policy.borrow_mut().sample(ns);
             let nqsna = self.q_func.borrow().evaluate_action(ns, na);
 

--- a/src/control/td/sarsa.rs
+++ b/src/control/td/sarsa.rs
@@ -11,17 +11,15 @@ use std::marker::PhantomData;
 /// thesis, Cambridge University.
 /// - Singh, S. P., Sutton, R. S. (1996). Reinforcement learning with replacing
 /// eligibility traces. Machine Learning 22:123–158.
-pub struct SARSA<S, Q, P> {
+pub struct SARSA<Q, P> {
     pub q_func: Shared<Q>,
     pub policy: Shared<P>,
 
     pub alpha: Parameter,
     pub gamma: Parameter,
-
-    phantom: PhantomData<S>,
 }
 
-impl<S, Q, P> SARSA<S, Q, P> {
+impl<Q, P> SARSA<Q, P> {
     pub fn new<T1, T2>(q_func: Shared<Q>, policy: Shared<P>, alpha: T1, gamma: T2) -> Self
     where
         T1: Into<Parameter>,
@@ -33,13 +31,11 @@ impl<S, Q, P> SARSA<S, Q, P> {
 
             alpha: alpha.into(),
             gamma: gamma.into(),
-
-            phantom: PhantomData,
         }
     }
 }
 
-impl<S, Q, P: Algorithm> Algorithm for SARSA<S, Q, P> {
+impl<Q, P: Algorithm> Algorithm for SARSA<Q, P> {
     fn handle_terminal(&mut self) {
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
@@ -48,7 +44,7 @@ impl<S, Q, P: Algorithm> Algorithm for SARSA<S, Q, P> {
     }
 }
 
-impl<S, Q, P> OnlineLearner<S, P::Action> for SARSA<S, Q, P>
+impl<S, Q, P> OnlineLearner<S, P::Action> for SARSA<Q, P>
 where
     Q: QFunction<S>,
     P: FinitePolicy<S>,
@@ -70,10 +66,7 @@ where
     }
 }
 
-impl<S, Q, P> Controller<S, P::Action> for SARSA<S, Q, P>
-where
-    P: Policy<S>,
-{
+impl<S, Q, P: Policy<S>> Controller<S, P::Action> for SARSA<Q, P> {
     fn sample_target(&mut self, s: &S) -> P::Action {
         self.policy.borrow_mut().sample(s)
     }
@@ -83,7 +76,7 @@ where
     }
 }
 
-impl<S, Q, P> ValuePredictor<S> for SARSA<S, Q, P>
+impl<S, Q, P> ValuePredictor<S> for SARSA<Q, P>
 where
     Q: QFunction<S>,
     P: FinitePolicy<S>,
@@ -93,7 +86,7 @@ where
     }
 }
 
-impl<S, Q, P> ActionValuePredictor<S, P::Action> for SARSA<S, Q, P>
+impl<S, Q, P> ActionValuePredictor<S, P::Action> for SARSA<Q, P>
 where
     Q: QFunction<S>,
     P: FinitePolicy<S>,
@@ -107,10 +100,7 @@ where
     }
 }
 
-impl<S, Q, P> Parameterised for SARSA<S, Q, P>
-where
-    Q: Parameterised,
-{
+impl<Q: Parameterised, P> Parameterised for SARSA<Q, P> {
     fn weights(&self) -> Matrix<f64> {
         self.q_func.borrow().weights()
     }

--- a/src/control/td/sarsa_lambda.rs
+++ b/src/control/td/sarsa_lambda.rs
@@ -68,8 +68,7 @@ where
     P: FinitePolicy<S>,
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
-        let (s, ns) = (t.from.state(), t.to.state());
-
+        let s = t.from.state();
         let phi_s = self.fa_theta.borrow().projector.project(s);
         let qsa = self.fa_theta.borrow().evaluate_action_phi(&phi_s, t.action);
 
@@ -85,6 +84,7 @@ where
 
             t.reward - qsa
         } else {
+            let ns = t.to.state();
             let na = self.policy.borrow_mut().sample(ns);
             let nqsna = self.fa_theta.borrow().evaluate_action(ns, na);
 

--- a/src/control/totd/to_q_lambda.rs
+++ b/src/control/totd/to_q_lambda.rs
@@ -73,8 +73,7 @@ where
     P: Policy<S, Action = <Greedy<VectorLFA<M>> as Policy<S>>::Action>,
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
-        let (s, ns) = (t.from.state(), t.to.state());
-
+        let s = t.from.state();
         let phi_s = self.q_func.borrow().projector.project(s);
 
         // Update traces:
@@ -100,6 +99,7 @@ where
             t.reward - q_old
 
         } else {
+            let ns = t.to.state();
             let na = self.sample_behaviour(ns);
             let nqsna = self.q_func.borrow().evaluate_action(ns, na);
 

--- a/src/control/totd/to_sarsa_lambda.rs
+++ b/src/control/totd/to_sarsa_lambda.rs
@@ -69,8 +69,7 @@ where
     P: Policy<S, Action = usize>,
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
-        let (s, ns) = (t.from.state(), t.to.state());
-
+        let s = t.from.state();
         let phi_s = self.q_func.borrow().projector.project(s);
 
         // Update traces:
@@ -91,6 +90,7 @@ where
             t.reward - q_old
 
         } else {
+            let ns = t.to.state();
             let na = self.sample_behaviour(ns);
             let nqsna = self.q_func.borrow().evaluate_action(ns, na);
 

--- a/src/control/totd/to_sarsa_lambda.rs
+++ b/src/control/totd/to_sarsa_lambda.rs
@@ -1,6 +1,6 @@
 use crate::core::*;
 use crate::domains::Transition;
-use crate::fa::{Approximator, Parameterised, MultiLFA, Projection, Projector, QFunction};
+use crate::fa::{Approximator, Parameterised, VectorLFA, Projection, Projector, QFunction};
 use crate::policies::{Policy, FinitePolicy};
 
 /// True online variant of the SARSA(lambda) algorithm.
@@ -9,8 +9,8 @@ use crate::policies::{Policy, FinitePolicy};
 /// - [Van Seijen, H., Mahmood, A. R., Pilarski, P. M., Machado, M. C., &
 /// Sutton, R. S. (2016). True online temporal-difference learning. Journal of
 /// Machine Learning Research, 17(145), 1-40.](https://arxiv.org/pdf/1512.04087.pdf)
-pub struct TOSARSALambda<S, M: Projector<S>, P> {
-    pub q_func: Shared<MultiLFA<S, M>>,
+pub struct TOSARSALambda<M, P> {
+    pub q_func: Shared<VectorLFA<M>>,
     pub policy: Shared<P>,
 
     pub alpha: Parameter,
@@ -20,13 +20,10 @@ pub struct TOSARSALambda<S, M: Projector<S>, P> {
     q_old: f64,
 }
 
-impl<S, M, P> TOSARSALambda<S, M, P>
-where
-    M: Projector<S>,
-{
+impl<M, P> TOSARSALambda<M, P> {
     pub fn new<T1, T2>(
         trace: Trace,
-        q_func: Shared<MultiLFA<S, M>>,
+        q_func: Shared<VectorLFA<M>>,
         policy: Shared<P>,
         alpha: T1,
         gamma: T2,
@@ -59,14 +56,14 @@ where
     }
 }
 
-impl<S, M: Projector<S>, P> Algorithm for TOSARSALambda<S, M, P> {
+impl<M, P> Algorithm for TOSARSALambda<M, P> {
     fn handle_terminal(&mut self) {
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
     }
 }
 
-impl<S, M, P> OnlineLearner<S, P::Action> for TOSARSALambda<S, M, P>
+impl<S, M, P> OnlineLearner<S, P::Action> for TOSARSALambda<M, P>
 where
     M: Projector<S>,
     P: Policy<S, Action = usize>,
@@ -114,9 +111,9 @@ where
     }
 }
 
-impl<S, M, P> Controller<S, P::Action> for TOSARSALambda<S, M, P>
+impl<S, M, P> Controller<S, P::Action> for TOSARSALambda<M, P>
 where
-    M: Projector<S>,
+    VectorLFA<M>: QFunction<S>,
     P: Policy<S>,
 {
     fn sample_target(&mut self, s: &S) -> P::Action {
@@ -128,9 +125,9 @@ where
     }
 }
 
-impl<S, M, P> ValuePredictor<S> for TOSARSALambda<S, M, P>
+impl<S, M, P> ValuePredictor<S> for TOSARSALambda<M, P>
 where
-    M: Projector<S>,
+    VectorLFA<M>: QFunction<S>,
     P: FinitePolicy<S>,
 {
     fn predict_v(&mut self, s: &S) -> f64 {
@@ -138,9 +135,9 @@ where
     }
 }
 
-impl<S, M, P> ActionValuePredictor<S, P::Action> for TOSARSALambda<S, M, P>
+impl<S, M, P> ActionValuePredictor<S, P::Action> for TOSARSALambda<M, P>
 where
-    M: Projector<S>,
+    VectorLFA<M>: QFunction<S>,
     P: FinitePolicy<S>,
 {
     fn predict_qs(&mut self, s: &S) -> Vector<f64> {
@@ -152,10 +149,7 @@ where
     }
 }
 
-impl<S, M, P> Parameterised for TOSARSALambda<S, M, P>
-where
-    M: Projector<S>,
-{
+impl<M, P> Parameterised for TOSARSALambda<M, P> {
     fn weights(&self) -> Matrix<f64> {
         self.q_func.borrow().weights()
     }

--- a/src/core/experiment.rs
+++ b/src/core/experiment.rs
@@ -146,14 +146,10 @@ where
 
             self.agent.handle_transition(&t);
 
-            if t.terminated() {
+            if t.terminated() || j >= self.step_limit {
                 self.agent.handle_terminal();
 
                 break
-
-            } else if j >= self.step_limit {
-                break
-
             } else {
                 a = self.agent.sample_behaviour(t.to.state());
             }

--- a/src/fa/mocking.rs
+++ b/src/fa/mocking.rs
@@ -24,6 +24,13 @@ impl MockQ {
 impl Approximator<Vector<f64>> for MockQ {
     type Value = Vector<f64>;
 
+    fn n_outputs(&self) -> usize {
+        match self.output {
+            Some(ref vector) => vector.len(),
+            None => 0,
+        }
+    }
+
     fn evaluate(&self, s: &Vector<f64>) -> EvaluationResult<Vector<f64>> {
         Ok(match self.output {
             Some(ref vector) => vector.clone(),
@@ -34,11 +41,4 @@ impl Approximator<Vector<f64>> for MockQ {
     fn update(&mut self, _: &Vector<f64>, _: Vector<f64>) -> UpdateResult<()> { Ok(()) }
 }
 
-impl QFunction<Vector<f64>> for MockQ {
-    fn n_actions(&self) -> usize {
-        match self.output {
-            Some(ref vector) => vector.len(),
-            None => 0,
-        }
-    }
-}
+impl QFunction<Vector<f64>> for MockQ {}

--- a/src/fa/table.rs
+++ b/src/fa/table.rs
@@ -39,6 +39,10 @@ where
 {
     type Value = V;
 
+    fn n_outputs(&self) -> usize {
+        unimplemented!()
+    }
+
     fn evaluate(&self, input: &I) -> EvaluationResult<V> {
         if self.0.contains_key(input) {
             Ok(self.0[input])

--- a/src/policies/fixed/boltzmann.rs
+++ b/src/policies/fixed/boltzmann.rs
@@ -1,19 +1,19 @@
 use crate::core::*;
 use crate::domains::Transition;
-use crate::fa::SharedQFunction;
+use crate::fa::QFunction;
 use crate::policies::{sample_probs_with_rng, FinitePolicy, Policy};
 use rand::{rngs::ThreadRng, thread_rng};
 use std::f64;
 
-pub struct Boltzmann<S> {
-    q_func: SharedQFunction<S>,
+pub struct Boltzmann<Q> {
+    q_func: Shared<Q>,
 
     tau: Parameter,
     rng: ThreadRng,
 }
 
-impl<S> Boltzmann<S> {
-    pub fn new<T: Into<Parameter>>(q_func: SharedQFunction<S>, tau: T) -> Self {
+impl<Q> Boltzmann<Q> {
+    pub fn new<T: Into<Parameter>>(q_func: Shared<Q>, tau: T) -> Self {
         Boltzmann {
             q_func,
 
@@ -23,11 +23,13 @@ impl<S> Boltzmann<S> {
     }
 }
 
-impl<S> Algorithm for Boltzmann<S> {
-    fn handle_terminal(&mut self) { self.tau = self.tau.step() }
+impl<Q> Algorithm for Boltzmann<Q> {
+    fn handle_terminal(&mut self) {
+        self.tau = self.tau.step();
+    }
 }
 
-impl<S> Policy<S> for Boltzmann<S> {
+impl<S, Q: QFunction<S>> Policy<S> for Boltzmann<Q> {
     type Action = usize;
 
     fn sample(&mut self, s: &S) -> usize {
@@ -39,7 +41,11 @@ impl<S> Policy<S> for Boltzmann<S> {
     fn probability(&mut self, s: &S, a: usize) -> f64 { self.probabilities(s)[a] }
 }
 
-impl<S> FinitePolicy<S> for Boltzmann<S> {
+impl<S, Q: QFunction<S>> FinitePolicy<S> for Boltzmann<Q> {
+    fn n_actions(&self) -> usize {
+        self.q_func.borrow().n_outputs()
+    }
+
     fn probabilities(&mut self, s: &S) -> Vector<f64> {
         let tau = self.tau.value();
 

--- a/src/policies/fixed/boltzmann.rs
+++ b/src/policies/fixed/boltzmann.rs
@@ -1,7 +1,7 @@
 use crate::core::*;
 use crate::domains::Transition;
 use crate::fa::SharedQFunction;
-use crate::policies::{sample_probs, FinitePolicy, Policy};
+use crate::policies::{sample_probs_with_rng, FinitePolicy, Policy};
 use rand::{rngs::ThreadRng, thread_rng};
 use std::f64;
 
@@ -33,7 +33,7 @@ impl<S> Policy<S> for Boltzmann<S> {
     fn sample(&mut self, s: &S) -> usize {
         let ps = self.probabilities(s);
 
-        sample_probs(&mut self.rng, ps.as_slice().unwrap())
+        sample_probs_with_rng(&mut self.rng, ps.as_slice().unwrap())
     }
 
     fn probability(&mut self, s: &S, a: usize) -> f64 { self.probabilities(s)[a] }

--- a/src/policies/fixed/epsilon_greedy.rs
+++ b/src/policies/fixed/epsilon_greedy.rs
@@ -1,32 +1,39 @@
 use crate::core::*;
 use crate::domains::Transition;
-use crate::fa::SharedQFunction;
+use crate::fa::QFunction;
 use rand::{rngs::ThreadRng, thread_rng, Rng};
 use super::{FinitePolicy, Greedy, Policy, Random};
 
-pub struct EpsilonGreedy<S> {
+pub struct EpsilonGreedy<Q> {
+    greedy: Greedy<Q>,
     random: Random,
-    greedy: Greedy<S>,
 
     epsilon: Parameter,
     rng: ThreadRng,
 }
 
-impl<S> EpsilonGreedy<S> {
-    pub fn new<T: Into<Parameter>>(q_func: SharedQFunction<S>, epsilon: T) -> Self {
-        let n_actions = q_func.borrow().n_actions();
-
+impl<Q> EpsilonGreedy<Q> {
+    pub fn new<T: Into<Parameter>>(greedy: Greedy<Q>, random: Random, epsilon: T) -> Self {
         EpsilonGreedy {
+            greedy, random,
+
             epsilon: epsilon.into(),
             rng: thread_rng(),
-
-            random: Random::new(n_actions),
-            greedy: Greedy::new(q_func),
         }
+    }
+
+    #[allow(non_snake_case)]
+    pub fn from_Q<S, T: Into<Parameter>>(q_func: Shared<Q>, epsilon: T) -> Self
+        where Q: QFunction<S>,
+    {
+        let greedy = Greedy::new(q_func);
+        let random = Random::new(greedy.n_actions());
+
+        EpsilonGreedy::new(greedy, random, epsilon)
     }
 }
 
-impl<S> Algorithm for EpsilonGreedy<S> {
+impl<Q> Algorithm for EpsilonGreedy<Q> {
     fn handle_terminal(&mut self) {
         self.epsilon = self.epsilon.step();
 
@@ -35,7 +42,7 @@ impl<S> Algorithm for EpsilonGreedy<S> {
     }
 }
 
-impl<S> Policy<S> for EpsilonGreedy<S> {
+impl<S, Q: QFunction<S>> Policy<S> for EpsilonGreedy<Q> {
     type Action = usize;
 
     fn sample(&mut self, s: &S) -> usize {
@@ -49,7 +56,11 @@ impl<S> Policy<S> for EpsilonGreedy<S> {
     fn probability(&mut self, s: &S, a: usize) -> f64 { self.probabilities(s)[a] }
 }
 
-impl<S> FinitePolicy<S> for EpsilonGreedy<S> {
+impl<S, Q: QFunction<S>> FinitePolicy<S> for EpsilonGreedy<Q> {
+    fn n_actions(&self) -> usize {
+        self.greedy.n_actions()
+    }
+
     fn probabilities(&mut self, s: &S) -> Vector<f64> {
         let prs = self.greedy.probabilities(s);
         let pr = self.epsilon / prs.len() as f64;
@@ -68,7 +79,7 @@ mod tests {
     #[test]
     fn test_sampling() {
         let q = MockQ::new_shared(Some(vec![0.0, 1.0].into()));
-        let mut p = EpsilonGreedy::new(q.clone(), 0.5);
+        let mut p = EpsilonGreedy::from_Q(q.clone(), 0.5);
 
         q.borrow_mut().clear_output();
 
@@ -89,7 +100,7 @@ mod tests {
 
     #[test]
     fn test_probabilites() {
-        let mut p = EpsilonGreedy::new(MockQ::new_shared(None), 0.5);
+        let mut p = EpsilonGreedy::from_Q(MockQ::new_shared(None), 0.5);
 
         assert!(p
             .probabilities(&vec![1.0, 0.0, 0.0, 0.0, 0.0].into())
@@ -103,7 +114,7 @@ mod tests {
             .probabilities(&vec![1.0, 0.0, 0.0, 0.0, 1.0].into())
             .all_close(&vec![0.35, 0.1, 0.1, 0.1, 0.35].into(), 1e-6));
 
-        let mut p = EpsilonGreedy::new(MockQ::new_shared(None), 1.0);
+        let mut p = EpsilonGreedy::from_Q(MockQ::new_shared(None), 1.0);
 
         assert!(p
             .probabilities(&vec![-1.0, 0.0, 0.0, 0.0].into())
@@ -113,7 +124,7 @@ mod tests {
     #[test]
     fn test_terminal() {
         let mut epsilon = Parameter::exponential(100.0, 1.0, 0.9);
-        let mut p = EpsilonGreedy::new(MockQ::new_shared(None), epsilon);
+        let mut p = EpsilonGreedy::from_Q(MockQ::new_shared(None), epsilon);
 
         for _ in 0..100 {
             epsilon = epsilon.step();

--- a/src/policies/fixed/greedy.rs
+++ b/src/policies/fixed/greedy.rs
@@ -1,18 +1,18 @@
 use crate::core::*;
-use crate::fa::SharedQFunction;
+use crate::fa::QFunction;
 use crate::policies::{FinitePolicy, Policy};
 use rand::{thread_rng, Rng, seq::SliceRandom};
 use crate::utils::argmaxima;
 
-pub struct Greedy<S>(SharedQFunction<S>);
+pub struct Greedy<Q>(Shared<Q>);
 
-impl<S> Greedy<S> {
-    pub fn new(q_func: SharedQFunction<S>) -> Self { Greedy(q_func) }
+impl<Q> Greedy<Q> {
+    pub fn new(q_func: Shared<Q>) -> Self { Greedy(q_func) }
 }
 
-impl<S> Algorithm for Greedy<S> {}
+impl<Q> Algorithm for Greedy<Q> {}
 
-impl<S> Policy<S> for Greedy<S> {
+impl<S, Q: QFunction<S>> Policy<S> for Greedy<Q> {
     type Action = usize;
 
     fn sample(&mut self, s: &S) -> usize {
@@ -31,7 +31,11 @@ impl<S> Policy<S> for Greedy<S> {
     fn probability(&mut self, s: &S, a: usize) -> f64 { self.probabilities(s)[a] }
 }
 
-impl<S> FinitePolicy<S> for Greedy<S> {
+impl<S, Q: QFunction<S>> FinitePolicy<S> for Greedy<Q> {
+    fn n_actions(&self) -> usize {
+        self.0.borrow().n_outputs()
+    }
+
     fn probabilities(&mut self, s: &S) -> Vector<f64> {
         let qs = self.0.borrow().evaluate(s).unwrap();
         let mut ps = vec![0.0; qs.len()];

--- a/src/policies/fixed/random.rs
+++ b/src/policies/fixed/random.rs
@@ -30,7 +30,11 @@ impl<S> Policy<S> for Random {
 }
 
 impl<S> FinitePolicy<S> for Random {
-    fn probabilities(&mut self, _: &S) -> Vector<f64> { vec![1.0 / self.0 as f64; self.0].into() }
+    fn n_actions(&self) -> usize { self.0 }
+
+    fn probabilities(&mut self, _: &S) -> Vector<f64> {
+        vec![1.0 / self.0 as f64; self.0].into()
+    }
 }
 
 #[cfg(test)]

--- a/src/policies/fixed/random.rs
+++ b/src/policies/fixed/random.rs
@@ -7,6 +7,10 @@ use rand::{
     thread_rng,
 };
 
+// TODO: Generalise the random policy to work on any `Space`. This won't be hard at all, just use
+// T: Into<Space>. Just make sure that you add all the relevant From implementations for the
+// different spaces in the `spaces` crate; i.e. From<usize> for Ordinal etc etc...
+
 pub struct Random(usize, ThreadRng);
 
 impl Random {

--- a/src/policies/fixed/truncated_boltzmann.rs
+++ b/src/policies/fixed/truncated_boltzmann.rs
@@ -3,7 +3,7 @@ use crate::domains::Transition;
 use crate::fa::SharedQFunction;
 use rand::{rngs::ThreadRng, thread_rng};
 use std::f64;
-use super::{sample_probs, FinitePolicy, Policy};
+use super::{sample_probs_with_rng, FinitePolicy, Policy};
 
 fn kappa(c: f64, x: f64) -> f64 { c / (1.0 + (-x).exp()) }
 
@@ -35,7 +35,7 @@ impl<S> Policy<S> for TruncatedBoltzmann<S> {
     fn sample(&mut self, s: &S) -> usize {
         let ps = self.probabilities(s);
 
-        sample_probs(&mut self.rng, ps.as_slice().unwrap())
+        sample_probs_with_rng(&mut self.rng, ps.as_slice().unwrap())
     }
 
     fn probability(&mut self, s: &S, a: usize) -> f64 { self.probabilities(s)[a] }

--- a/src/policies/mod.rs
+++ b/src/policies/mod.rs
@@ -1,11 +1,29 @@
 //! Agent policy module.
+//!
+//! This module contains [fixed](fixed/index.html) and [parameterised](parameterised/index.html)
+//! policies for reinforcement learning control problems. A policy is considered to be either
+//! deterministic or stochastic, for which we have the following definitions, respectively:
+//! 1) _π(X) -> U_;
+//! 2) _π(X, U) -> R_, or equivalently, _π(x) -> Ω(U)_;
+//!
+//! where _X_ and _U_ are the state and action spaces, respectively; _R_ is the set of real values;
+//! and _Ω(U)_ is the set of probability measures on the action set _U_. In general, deterministic
+//! policies may be considered a special case of stochastic policies in which all probability mass
+//! is placed on a single action _u'_ for any given state _x_. For continuous policies, this can be
+//! seen as a dirac delta distribution, _δ(u' - u)_.
 use crate::core::*;
 use crate::domains::Transition;
 use crate::fa::Parameterised;
-use rand::Rng;
+use rand::{thread_rng, Rng};
+
+#[allow(dead_code)]
+#[inline]
+pub(self) fn sample_probs(probabilities: &[f64]) -> usize {
+    sample_probs_with_rng(&mut thread_rng(), probabilities)
+}
 
 #[inline]
-pub(self) fn sample_probs<R: Rng + ?Sized>(rng: &mut R, probabilities: &[f64]) -> usize {
+pub(self) fn sample_probs_with_rng<R: Rng + ?Sized>(rng: &mut R, probabilities: &[f64]) -> usize {
     let r = rng.gen::<f64>();
     let n_actions = probabilities.len();
 
@@ -15,7 +33,7 @@ pub(self) fn sample_probs<R: Rng + ?Sized>(rng: &mut R, probabilities: &[f64]) -
     }
 }
 
-/// Policy trait for functions that select between a set of values.
+/// Policy trait for functions that define a probability distribution over actions.
 pub trait Policy<S>: Algorithm {
     type Action;
 
@@ -26,18 +44,24 @@ pub trait Policy<S>: Algorithm {
     fn probability(&mut self, input: &S, a: Self::Action) -> f64;
 }
 
+/// Trait for policies that are defined on a finite action space.
 pub trait FinitePolicy<S>: Policy<S, Action = usize> {
     /// Return the probability of selecting each action for a given input.
     fn probabilities(&mut self, input: &S) -> Vector<f64>;
 }
 
+/// Trait for policies that have a differentiable representation.
 pub trait DifferentiablePolicy<S>: Policy<S> {
     /// Compute the derivative of the log probability for a single action.
     fn grad_log(&self, input: &S, a: Self::Action) -> Matrix<f64>;
 }
 
+/// Trait for policies that are parameterised by a vector of weights.
 pub trait ParameterisedPolicy<S>: Policy<S> + Parameterised {
+    /// Update the weights in the direction of an error for a given state and action.
     fn update(&mut self, input: &S, a: Self::Action, error: f64);
+
+    /// Update the weights directly using an update matrix.
     fn update_raw(&mut self, errors: Matrix<f64>);
 }
 

--- a/src/policies/mod.rs
+++ b/src/policies/mod.rs
@@ -46,6 +46,8 @@ pub trait Policy<S>: Algorithm {
 
 /// Trait for policies that are defined on a finite action space.
 pub trait FinitePolicy<S>: Policy<S, Action = usize> {
+    fn n_actions(&self) -> usize;
+
     /// Return the probability of selecting each action for a given input.
     fn probabilities(&mut self, input: &S) -> Vector<f64>;
 }

--- a/src/policies/parameterised/gibbs.rs
+++ b/src/policies/parameterised/gibbs.rs
@@ -1,11 +1,11 @@
 use crate::core::*;
-use crate::fa::{Approximator, MultiLFA, Parameterised, Projector};
+use crate::fa::{Approximator, VectorLFA, Parameterised, Projector};
 use crate::policies::{DifferentiablePolicy, FinitePolicy, ParameterisedPolicy, Policy};
 use rand::{rngs::ThreadRng, thread_rng, Rng};
 use std::{f64, ops::AddAssign};
 
-pub struct Gibbs<S, M: Projector<S>> {
-    pub fa: MultiLFA<S, M>,
+pub struct Gibbs<F> {
+    pub fa: F,
 
     rng: ThreadRng,
 }
@@ -25,8 +25,8 @@ fn probabilities_from_values(values: &[f64]) -> Vector<f64> {
     ws.iter().map(|w| (w / z).min(1e50)).collect()
 }
 
-impl<S, M: Projector<S>> Gibbs<S, M> {
-    pub fn new(fa: MultiLFA<S, M>) -> Self {
+impl<F> Gibbs<F> {
+    pub fn new(fa: F) -> Self {
         Gibbs {
             fa,
 
@@ -35,16 +35,20 @@ impl<S, M: Projector<S>> Gibbs<S, M> {
     }
 }
 
-impl<S, M: Projector<S>> Algorithm for Gibbs<S, M> {}
+impl<F> Algorithm for Gibbs<F> {}
 
-impl<S, M: Projector<S>> Policy<S> for Gibbs<S, M> {
+impl<S, M: Projector<S>> Policy<S> for Gibbs<VectorLFA<M>> {
     type Action = usize;
 
     fn sample(&mut self, input: &S) -> usize {
         let ps = self.probabilities(input);
 
         let r = self.rng.gen::<f64>();
-        match ps.iter().position(|p| *p > r) {
+        match ps.iter().scan(0.0, |state, &p| {
+            *state = *state + p;
+
+            Some(*state)
+        }).position(|p| p > r) {
             Some(index) => index,
             None => ps.len() - 1,
         }
@@ -53,7 +57,11 @@ impl<S, M: Projector<S>> Policy<S> for Gibbs<S, M> {
     fn probability(&mut self, input: &S, a: usize) -> f64 { self.probabilities(input)[a] }
 }
 
-impl<S, M: Projector<S>> FinitePolicy<S> for Gibbs<S, M> {
+impl<S, M: Projector<S>> FinitePolicy<S> for Gibbs<VectorLFA<M>> {
+    fn n_actions(&self) -> usize {
+        self.fa.n_outputs()
+    }
+
     fn probabilities(&mut self, input: &S) -> Vector<f64> {
         let values = self.fa.evaluate(input).unwrap();
 
@@ -61,11 +69,11 @@ impl<S, M: Projector<S>> FinitePolicy<S> for Gibbs<S, M> {
     }
 }
 
-impl<S, M: Projector<S>> DifferentiablePolicy<S> for Gibbs<S, M> {
+impl<S, M: Projector<S>> DifferentiablePolicy<S> for Gibbs<VectorLFA<M>> {
     fn grad_log(&self, input: &S, a: usize) -> Matrix<f64> {
         let phi = self.fa.projector.project(input);
 
-        let values = self.fa.approximator.evaluate(&phi).unwrap();
+        let values = self.fa.evaluate_primal(&phi).unwrap();
         let n_actions = values.len();
         let probabilities = probabilities_from_values(values.as_slice().unwrap())
             .into_shape((1, n_actions))
@@ -85,11 +93,11 @@ impl<S, M: Projector<S>> DifferentiablePolicy<S> for Gibbs<S, M> {
     }
 }
 
-impl<S, M: Projector<S>> Parameterised for Gibbs<S, M> {
-    fn weights(&self) -> Matrix<f64> { self.fa.approximator.weights.clone() }
+impl<F: Parameterised> Parameterised for Gibbs<F> {
+    fn weights(&self) -> Matrix<f64> { self.fa.weights() }
 }
 
-impl<S, M: Projector<S>> ParameterisedPolicy<S> for Gibbs<S, M> {
+impl<S, M: Projector<S>> ParameterisedPolicy<S> for Gibbs<VectorLFA<M>> {
     fn update(&mut self, input: &S, a: usize, error: f64) {
         let pi = self.probability(input, a);
         let grad_log = self.grad_log(input, a);
@@ -102,5 +110,26 @@ impl<S, M: Projector<S>> ParameterisedPolicy<S> for Gibbs<S, M> {
 
     fn update_raw(&mut self, errors: Matrix<f64>) {
         self.fa.approximator.weights.add_assign(&errors)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::fa::{LFA, Parameterised, basis::fixed::Polynomial};
+    use crate::policies::{Policy, ParameterisedPolicy};
+    use super::Gibbs;
+
+    #[test]
+    fn test_sample() {
+        let fa = LFA::vector_output(Polynomial::new(1, vec![(0.0, 1.0)]), 3);
+        let mut p = Gibbs::new(fa);
+
+        for _ in 0..10 {
+            p.update(&vec![0.0], 0, -100.0);
+            p.update(&vec![0.0], 1, 100.0);
+            p.update(&vec![0.0], 2, -100.0);
+        }
+
+        assert_eq!(p.sample(&vec![0.0]), 1);
     }
 }

--- a/src/policies/parameterised/mod.rs
+++ b/src/policies/parameterised/mod.rs
@@ -1,7 +1,4 @@
-mod gibbs;
-pub use self::gibbs::*;
-
-mod gaussian;
-pub use self::gaussian::*;
+import_all!(gibbs);
+import_all!(gaussian);
 
 pub(self) mod pdfs;

--- a/src/prediction/gtd/gtd2.rs
+++ b/src/prediction/gtd/gtd2.rs
@@ -50,8 +50,7 @@ impl<M> Algorithm for GTD2<M> {
 
 impl<S, A, M: Projector<S>> OnlineLearner<S, A> for GTD2<M> {
     fn handle_transition(&mut self, t: &Transition<S, A>) {
-        let phi_s = self.fa_theta.borrow().projector.project(&t.from.state());
-        let phi_ns = self.fa_theta.borrow().projector.project(&t.to.state());
+        let (phi_s, phi_ns) = t.map_states(|s| self.fa_theta.borrow().projector.project(s));
 
         let v = self.fa_theta.borrow().evaluate_phi(&phi_s);
 

--- a/src/prediction/gtd/gtd2.rs
+++ b/src/prediction/gtd/gtd2.rs
@@ -1,20 +1,21 @@
 use crate::core::*;
 use crate::domains::Transition;
-use crate::fa::{Approximator, Parameterised, Projection, Projector, SimpleLFA, VFunction};
+use crate::fa::{Approximator, Parameterised, Projection, Projector, ScalarLFA, VFunction};
+use crate::geometry::Space;
 
-pub struct GTD2<S, P: Projector<S>> {
-    pub fa_theta: Shared<SimpleLFA<S, P>>,
-    pub fa_w: Shared<SimpleLFA<S, P>>,
+pub struct GTD2<M> {
+    pub fa_theta: Shared<ScalarLFA<M>>,
+    pub fa_w: Shared<ScalarLFA<M>>,
 
     pub alpha: Parameter,
     pub beta: Parameter,
     pub gamma: Parameter,
 }
 
-impl<S, P: Projector<S>> GTD2<S, P> {
+impl<M: Space> GTD2<M> {
     pub fn new<T1, T2, T3>(
-        fa_theta: Shared<SimpleLFA<S, P>>,
-        fa_w: Shared<SimpleLFA<S, P>>,
+        fa_theta: Shared<ScalarLFA<M>>,
+        fa_w: Shared<ScalarLFA<M>>,
         alpha: T1,
         beta: T2,
         gamma: T3,
@@ -39,7 +40,7 @@ impl<S, P: Projector<S>> GTD2<S, P> {
     }
 }
 
-impl<S, M: Projector<S>> Algorithm for GTD2<S, M> {
+impl<M> Algorithm for GTD2<M> {
     fn handle_terminal(&mut self) {
         self.alpha = self.alpha.step();
         self.beta = self.alpha.step();
@@ -47,7 +48,7 @@ impl<S, M: Projector<S>> Algorithm for GTD2<S, M> {
     }
 }
 
-impl<S, A, M: Projector<S>> OnlineLearner<S, A> for GTD2<S, M> {
+impl<S, A, M: Projector<S>> OnlineLearner<S, A> for GTD2<M> {
     fn handle_transition(&mut self, t: &Transition<S, A>) {
         let phi_s = self.fa_theta.borrow().projector.project(&t.from.state());
         let phi_ns = self.fa_theta.borrow().projector.project(&t.to.state());
@@ -70,15 +71,24 @@ impl<S, A, M: Projector<S>> OnlineLearner<S, A> for GTD2<S, M> {
     }
 }
 
-impl<S, P: Projector<S>> ValuePredictor<S> for GTD2<S, P> {
+impl<S, M> ValuePredictor<S> for GTD2<M>
+where
+    ScalarLFA<M>: VFunction<S>,
+{
     fn predict_v(&mut self, s: &S) -> f64 {
         self.fa_theta.borrow().evaluate(s).unwrap()
     }
 }
 
-impl<S, A, P: Projector<S>> ActionValuePredictor<S, A> for GTD2<S, P> {}
+impl<S, A, M> ActionValuePredictor<S, A> for GTD2<M>
+where
+    ScalarLFA<M>: VFunction<S>,
+{}
 
-impl<S, P: Projector<S>> Parameterised for GTD2<S, P> {
+impl<M> Parameterised for GTD2<M>
+where
+    ScalarLFA<M>: Parameterised,
+{
     fn weights(&self) -> Matrix<f64> {
         self.fa_theta.borrow().weights()
     }

--- a/src/prediction/gtd/tdc.rs
+++ b/src/prediction/gtd/tdc.rs
@@ -1,20 +1,21 @@
 use crate::core::*;
 use crate::domains::Transition;
-use crate::fa::{Approximator, Parameterised, Projection, Projector, SimpleLFA, VFunction};
+use crate::fa::{Approximator, Parameterised, Projection, Projector, ScalarLFA, VFunction};
+use crate::geometry::Space;
 
-pub struct TDC<S, P: Projector<S>> {
-    pub fa_theta: Shared<SimpleLFA<S, P>>,
-    pub fa_w: Shared<SimpleLFA<S, P>>,
+pub struct TDC<M> {
+    pub fa_theta: Shared<ScalarLFA<M>>,
+    pub fa_w: Shared<ScalarLFA<M>>,
 
     pub alpha: Parameter,
     pub beta: Parameter,
     pub gamma: Parameter,
 }
 
-impl<S, P: Projector<S>> TDC<S, P> {
+impl<M: Space> TDC<M> {
     pub fn new<T1, T2, T3>(
-        fa_theta: Shared<SimpleLFA<S, P>>,
-        fa_w: Shared<SimpleLFA<S, P>>,
+        fa_theta: Shared<ScalarLFA<M>>,
+        fa_w: Shared<ScalarLFA<M>>,
         alpha: T1,
         beta: T2,
         gamma: T3,
@@ -39,7 +40,7 @@ impl<S, P: Projector<S>> TDC<S, P> {
     }
 }
 
-impl<S, M: Projector<S>> Algorithm for TDC<S, M> {
+impl<M> Algorithm for TDC<M> {
     fn handle_terminal(&mut self) {
         self.alpha = self.alpha.step();
         self.beta = self.alpha.step();
@@ -47,7 +48,7 @@ impl<S, M: Projector<S>> Algorithm for TDC<S, M> {
     }
 }
 
-impl<S, A, M: Projector<S>> OnlineLearner<S, A> for TDC<S, M> {
+impl<S, A, M: Projector<S>> OnlineLearner<S, A> for TDC<M> {
     fn handle_transition(&mut self, t: &Transition<S, A>) {
         let phi_s = self.fa_theta.borrow().projector.project(&t.from.state());
         let phi_ns = self.fa_theta.borrow().projector.project(&t.to.state());
@@ -72,15 +73,24 @@ impl<S, A, M: Projector<S>> OnlineLearner<S, A> for TDC<S, M> {
     }
 }
 
-impl<S, P: Projector<S>> ValuePredictor<S> for TDC<S, P> {
+impl<S, M> ValuePredictor<S> for TDC<M>
+where
+    ScalarLFA<M>: VFunction<S>,
+{
     fn predict_v(&mut self, s: &S) -> f64 {
         self.fa_theta.borrow().evaluate(s).unwrap()
     }
 }
 
-impl<S, A, P: Projector<S>> ActionValuePredictor<S, A> for TDC<S, P> {}
+impl<S, A, M> ActionValuePredictor<S, A> for TDC<M>
+where
+    ScalarLFA<M>: VFunction<S>,
+{}
 
-impl<S, P: Projector<S>> Parameterised for TDC<S, P> {
+impl<M> Parameterised for TDC<M>
+where
+    ScalarLFA<M>: Parameterised,
+{
     fn weights(&self) -> Matrix<f64> {
         self.fa_theta.borrow().weights()
     }

--- a/src/prediction/gtd/tdc.rs
+++ b/src/prediction/gtd/tdc.rs
@@ -50,8 +50,7 @@ impl<M> Algorithm for TDC<M> {
 
 impl<S, A, M: Projector<S>> OnlineLearner<S, A> for TDC<M> {
     fn handle_transition(&mut self, t: &Transition<S, A>) {
-        let phi_s = self.fa_theta.borrow().projector.project(&t.from.state());
-        let phi_ns = self.fa_theta.borrow().projector.project(&t.to.state());
+        let (phi_s, phi_ns) = t.map_states(|s| self.fa_theta.borrow().projector.project(s));
 
         let v = self.fa_theta.borrow().evaluate_phi(&phi_s);
 

--- a/src/prediction/lstd/ilstd.rs
+++ b/src/prediction/lstd/ilstd.rs
@@ -1,13 +1,13 @@
 use crate::core::*;
 use crate::domains::Transition;
-use crate::fa::{Approximator, VFunction, Parameterised, Projector, Projection, SimpleLFA};
+use crate::fa::{Approximator, VFunction, Parameterised, Projector, Projection, ScalarLFA};
 use crate::geometry::Space;
 use ndarray::Axis;
 use crate::utils::argmaxima;
 
 #[allow(non_camel_case_types)]
-pub struct iLSTD<S, P: Projector<S>> {
-    pub fa_theta: Shared<SimpleLFA<S, P>>,
+pub struct iLSTD<M> {
+    pub fa_theta: Shared<ScalarLFA<M>>,
 
     pub alpha: Parameter,
     pub gamma: Parameter,
@@ -17,10 +17,9 @@ pub struct iLSTD<S, P: Projector<S>> {
     mu: Vector<f64>,
 }
 
-impl<S, P: Projector<S>> iLSTD<S, P> {
-    pub fn new<T1, T2>(fa_theta: Shared<SimpleLFA<S, P>>,
-                       n_updates: usize,
-                       alpha: T1, gamma: T2) -> Self
+impl<M: Space> iLSTD<M> {
+    pub fn new<T1, T2>(fa_theta: Shared<ScalarLFA<M>>,
+                       n_updates: usize, alpha: T1, gamma: T2) -> Self
         where T1: Into<Parameter>,
               T2: Into<Parameter>
     {
@@ -39,12 +38,7 @@ impl<S, P: Projector<S>> iLSTD<S, P> {
     }
 }
 
-impl<S, P: Projector<S>> iLSTD<S, P> {
-    #[inline(always)]
-    fn compute_dense_fv(&self, s: &S) -> Vector<f64> {
-        self.fa_theta.borrow().projector.project(s).expanded(self.a.rows())
-    }
-
+impl<M> iLSTD<M> {
     fn solve(&mut self) {
         let mut fa = self.fa_theta.borrow_mut();
         let alpha = self.alpha.value();
@@ -64,20 +58,20 @@ impl<S, P: Projector<S>> iLSTD<S, P> {
     }
 }
 
-impl<S, P: Projector<S>> Algorithm for iLSTD<S, P> {
+impl<M> Algorithm for iLSTD<M> {
     fn handle_terminal(&mut self) {
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
     }
 }
 
-impl<S, A, P: Projector<S>> OnlineLearner<S, A> for iLSTD<S, P> {
+impl<S, A, M: Projector<S>> OnlineLearner<S, A> for iLSTD<M> {
     fn handle_transition(&mut self, t: &Transition<S, A>) {
         let (s, ns) = (t.from.state(), t.to.state());
 
         // (D x 1)
-        let phi_s = self.compute_dense_fv(s);
-        let phi_ns = self.compute_dense_fv(ns);
+        let phi_s = self.fa_theta.borrow().projector.project(s).expanded(self.a.rows());
+        let phi_ns = self.fa_theta.borrow().projector.project(ns).expanded(self.a.rows());
 
         // (1 x D)
         let pd = if t.terminated() {
@@ -98,15 +92,24 @@ impl<S, A, P: Projector<S>> OnlineLearner<S, A> for iLSTD<S, P> {
     }
 }
 
-impl<S, P: Projector<S>> ValuePredictor<S> for iLSTD<S, P> {
+impl<S, M> ValuePredictor<S> for iLSTD<M>
+where
+    ScalarLFA<M>: VFunction<S>,
+{
     fn predict_v(&mut self, s: &S) -> f64 {
         self.fa_theta.borrow().evaluate(s).unwrap()
     }
 }
 
-impl<S, A, P: Projector<S>> ActionValuePredictor<S, A> for iLSTD<S, P> {}
+impl<S, A, M> ActionValuePredictor<S, A> for iLSTD<M>
+where
+    ScalarLFA<M>: VFunction<S>,
+{}
 
-impl<S, P: Projector<S>> Parameterised for iLSTD<S, P> {
+impl<M> Parameterised for iLSTD<M>
+where
+    ScalarLFA<M>: Parameterised,
+{
     fn weights(&self) -> Matrix<f64> {
         self.fa_theta.borrow().weights()
     }

--- a/src/prediction/lstd/lambda_lspe.rs
+++ b/src/prediction/lstd/lambda_lspe.rs
@@ -1,13 +1,13 @@
 use crate::core::*;
 use crate::domains::Transition;
-use crate::fa::{Approximator, VFunction, Parameterised, Projector, Projection, SimpleLFA};
+use crate::fa::{Approximator, VFunction, Parameterised, Projector, Projection, ScalarLFA};
 use crate::geometry::Space;
 use ndarray::Axis;
 use ndarray_linalg::solve::Solve;
 use crate::utils::{argmaxima, pinv};
 
-pub struct LambdaLSPE<S, P: Projector<S>> {
-    pub fa_theta: Shared<SimpleLFA<S, P>>,
+pub struct LambdaLSPE<M> {
+    pub fa_theta: Shared<ScalarLFA<M>>,
 
     pub alpha: Parameter,
     pub gamma: Parameter,
@@ -18,9 +18,9 @@ pub struct LambdaLSPE<S, P: Projector<S>> {
     delta: f64,
 }
 
-impl<S, P: Projector<S>> LambdaLSPE<S, P> {
-    pub fn new<T1, T2, T3>(fa_theta: Shared<SimpleLFA<S, P>>, alpha: T1, gamma: T2,
-                           lambda: T3) -> Self
+impl<M: Space> LambdaLSPE<M> {
+    pub fn new<T1, T2, T3>(fa_theta: Shared<ScalarLFA<M>>,
+                           alpha: T1, gamma: T2, lambda: T3) -> Self
     where
         T1: Into<Parameter>,
         T2: Into<Parameter>,
@@ -42,12 +42,7 @@ impl<S, P: Projector<S>> LambdaLSPE<S, P> {
     }
 }
 
-impl<S, P: Projector<S>> LambdaLSPE<S, P> {
-    #[inline(always)]
-    fn compute_dense_fv(&self, s: &S) -> Vector<f64> {
-        self.fa_theta.borrow().projector.project(s).expanded(self.a.rows())
-    }
-
+impl<M> LambdaLSPE<M> {
     #[inline(always)]
     fn compute_v(&self, phi: &Vector<f64>) -> f64 {
         self.fa_theta.borrow().approximator.weights.dot(phi)
@@ -68,7 +63,7 @@ impl<S, P: Projector<S>> LambdaLSPE<S, P> {
     }
 }
 
-impl<S, P: Projector<S>> Algorithm for LambdaLSPE<S, P> {
+impl<M> Algorithm for LambdaLSPE<M> {
     fn handle_terminal(&mut self) {
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
@@ -76,11 +71,13 @@ impl<S, P: Projector<S>> Algorithm for LambdaLSPE<S, P> {
     }
 }
 
-impl<S, A, P: Projector<S>> BatchLearner<S, A> for LambdaLSPE<S, P> {
+impl<S, A, M: Projector<S>> BatchLearner<S, A> for LambdaLSPE<M> {
     fn handle_batch(&mut self, batch: &[Transition<S, A>]) {
         batch.into_iter().rev().for_each(|ref t| {
-            let phi_s = self.compute_dense_fv(t.from.state());
-            let phi_ns = self.compute_dense_fv(t.to.state());
+            let (s, ns) = (t.from.state(), t.to.state());
+
+            let phi_s = self.fa_theta.borrow().projector.project(s).expanded(self.a.rows());
+            let phi_ns = self.fa_theta.borrow().projector.project(ns).expanded(self.a.rows());
 
             let v = self.compute_v(&phi_s);
 
@@ -104,15 +101,24 @@ impl<S, A, P: Projector<S>> BatchLearner<S, A> for LambdaLSPE<S, P> {
     }
 }
 
-impl<S, P: Projector<S>> ValuePredictor<S> for LambdaLSPE<S, P> {
+impl<S, M> ValuePredictor<S> for LambdaLSPE<M>
+where
+    ScalarLFA<M>: VFunction<S>,
+{
     fn predict_v(&mut self, s: &S) -> f64 {
         self.fa_theta.borrow().evaluate(s).unwrap()
     }
 }
 
-impl<S, A, P: Projector<S>> ActionValuePredictor<S, A> for LambdaLSPE<S, P> {}
+impl<S, A, M> ActionValuePredictor<S, A> for LambdaLSPE<M>
+where
+    ScalarLFA<M>: VFunction<S>,
+{}
 
-impl<S, P: Projector<S>> Parameterised for LambdaLSPE<S, P> {
+impl<M> Parameterised for LambdaLSPE<M>
+where
+    ScalarLFA<M>: Parameterised,
+{
     fn weights(&self) -> Matrix<f64> {
         self.fa_theta.borrow().weights()
     }

--- a/src/prediction/lstd/lstd.rs
+++ b/src/prediction/lstd/lstd.rs
@@ -1,13 +1,13 @@
 use crate::core::*;
 use crate::domains::Transition;
-use crate::fa::{Approximator, VFunction, Parameterised, Projector, Projection, SimpleLFA};
+use crate::fa::{Approximator, VFunction, Parameterised, Projector, Projection, ScalarLFA};
 use crate::geometry::Space;
 use ndarray::Axis;
 use ndarray_linalg::solve::Solve;
 use crate::utils::{argmaxima, pinv};
 
-pub struct LSTD<S, P: Projector<S>> {
-    pub fa_theta: Shared<SimpleLFA<S, P>>,
+pub struct LSTD<M> {
+    pub fa_theta: Shared<ScalarLFA<M>>,
 
     pub gamma: Parameter,
 
@@ -15,8 +15,8 @@ pub struct LSTD<S, P: Projector<S>> {
     b: Vector<f64>,
 }
 
-impl<S, P: Projector<S>> LSTD<S, P> {
-    pub fn new<T: Into<Parameter>>(fa_theta: Shared<SimpleLFA<S, P>>, gamma: T) -> Self {
+impl<M: Space> LSTD<M> {
+    pub fn new<T: Into<Parameter>>(fa_theta: Shared<ScalarLFA<M>>, gamma: T) -> Self {
         let n_features = fa_theta.borrow().projector.dim();
 
         LSTD {
@@ -30,13 +30,30 @@ impl<S, P: Projector<S>> LSTD<S, P> {
     }
 }
 
-impl<S, P: Projector<S>> LSTD<S, P> {
-    #[inline(always)]
-    fn compute_dense_fv(&self, s: &S) -> Vector<f64> {
-        self.fa_theta.borrow().projector.project(s).expanded(self.a.rows())
+impl<M> Algorithm for LSTD<M> {
+    fn handle_terminal(&mut self) {
+        self.gamma = self.gamma.step();
     }
+}
 
-    fn solve(&mut self) {
+impl<S, A, M: Projector<S>> BatchLearner<S, A> for LSTD<M> {
+    fn handle_batch(&mut self, ts: &[Transition<S, A>]) {
+        ts.into_iter().for_each(|ref t| {
+            let (s, ns) = (t.from.state(), t.to.state());
+
+            let phi_s = self.fa_theta.borrow().projector.project(s).expanded(self.a.rows());
+            let phi_ns = self.fa_theta.borrow().projector.project(ns).expanded(self.a.rows());
+
+            let pd = if t.terminated() {
+                phi_s.clone()
+            } else {
+                phi_s.clone() - self.gamma.value()*phi_ns.clone()
+            }.insert_axis(Axis(0));
+
+            self.b.scaled_add(t.reward, &phi_s);
+            self.a += &phi_s.insert_axis(Axis(1)).dot(&pd);
+        });
+
         // First try the clean approach:
         if let Ok(theta) = self.a.solve(&self.b) {
             self.fa_theta.borrow_mut().approximator.weights.assign(&theta);
@@ -50,43 +67,24 @@ impl<S, P: Projector<S>> LSTD<S, P> {
     }
 }
 
-impl<S, P: Projector<S>> Algorithm for LSTD<S, P> {
-    fn handle_terminal(&mut self) {
-        self.gamma = self.gamma.step();
-    }
-}
-
-impl<S, A, P: Projector<S>> BatchLearner<S, A> for LSTD<S, P> {
-    fn handle_batch(&mut self, ts: &[Transition<S, A>]) {
-        ts.into_iter().for_each(|ref t| {
-            let (s, ns) = (t.from.state(), t.to.state());
-
-            let phi_s = self.compute_dense_fv(s);
-            let phi_ns = self.compute_dense_fv(ns);
-
-            let pd = if t.terminated() {
-                phi_s.clone()
-            } else {
-                phi_s.clone() - self.gamma.value()*phi_ns.clone()
-            }.insert_axis(Axis(0));
-
-            self.b.scaled_add(t.reward, &phi_s);
-            self.a += &phi_s.insert_axis(Axis(1)).dot(&pd);
-        });
-
-        self.solve();
-    }
-}
-
-impl<S, P: Projector<S>> ValuePredictor<S> for LSTD<S, P> {
+impl<S, M> ValuePredictor<S> for LSTD<M>
+where
+    ScalarLFA<M>: VFunction<S>,
+{
     fn predict_v(&mut self, s: &S) -> f64 {
         self.fa_theta.borrow().evaluate(s).unwrap()
     }
 }
 
-impl<S, A, P: Projector<S>> ActionValuePredictor<S, A> for LSTD<S, P> {}
+impl<S, A, M> ActionValuePredictor<S, A> for LSTD<M>
+where
+    ScalarLFA<M>: VFunction<S>,
+{}
 
-impl<S, P: Projector<S>> Parameterised for LSTD<S, P> {
+impl<M> Parameterised for LSTD<M>
+where
+    ScalarLFA<M>: Parameterised
+{
     fn weights(&self) -> Matrix<f64> {
         self.fa_theta.borrow().weights()
     }

--- a/src/prediction/lstd/lstd.rs
+++ b/src/prediction/lstd/lstd.rs
@@ -39,14 +39,16 @@ impl<M> Algorithm for LSTD<M> {
 impl<S, A, M: Projector<S>> BatchLearner<S, A> for LSTD<M> {
     fn handle_batch(&mut self, ts: &[Transition<S, A>]) {
         ts.into_iter().for_each(|ref t| {
-            let (s, ns) = (t.from.state(), t.to.state());
-
-            let phi_s = self.fa_theta.borrow().projector.project(s).expanded(self.a.rows());
-            let phi_ns = self.fa_theta.borrow().projector.project(ns).expanded(self.a.rows());
-
+            let phi_s = self.fa_theta.borrow().projector
+                .project(t.from.state())
+                .expanded(self.a.rows());
             let pd = if t.terminated() {
                 phi_s.clone()
             } else {
+                let phi_ns = self.fa_theta.borrow().projector
+                    .project(t.to.state())
+                    .expanded(self.a.rows());
+
                 phi_s.clone() - self.gamma.value()*phi_ns.clone()
             }.insert_axis(Axis(0));
 

--- a/src/prediction/lstd/lstd_lambda.rs
+++ b/src/prediction/lstd/lstd_lambda.rs
@@ -68,9 +68,9 @@ impl<M> Algorithm for LSTDLambda<M> {
 impl<S, A, M: Projector<S>> BatchLearner<S, A> for LSTDLambda<M> {
     fn handle_batch(&mut self, ts: &[Transition<S, A>]) {
         ts.into_iter().for_each(|t| {
-            let (s, ns) = (t.from.state(), t.to.state());
-
-            let phi_s = self.fa_theta.borrow().projector.project(s).expanded(self.a.rows());
+            let phi_s = self.fa_theta.borrow().projector
+                .project(t.from.state())
+                .expanded(self.a.rows());
             let z = self.update_trace(&phi_s);
 
             self.b.scaled_add(t.reward, &z);
@@ -80,7 +80,9 @@ impl<S, A, M: Projector<S>> BatchLearner<S, A> for LSTDLambda<M> {
 
                 phi_s
             } else {
-                let phi_ns = self.fa_theta.borrow().projector.project(ns).expanded(self.a.rows());
+                let phi_ns = self.fa_theta.borrow().projector
+                    .project(t.to.state())
+                    .expanded(self.a.rows());
 
                 phi_s - self.gamma.value()*phi_ns
             }.insert_axis(Axis(0));

--- a/src/prediction/lstd/recursive_lstd.rs
+++ b/src/prediction/lstd/recursive_lstd.rs
@@ -1,25 +1,23 @@
 use crate::core::*;
 use crate::domains::Transition;
-use crate::fa::{Approximator, VFunction, Parameterised, Projector, Projection, SimpleLFA};
+use crate::fa::{Approximator, VFunction, Parameterised, Projector, Projection, ScalarLFA};
 use crate::geometry::Space;
 use ndarray::Axis;
 use crate::utils::argmaxima;
 
-pub struct RecursiveLSTD<S, P: Projector<S>> {
-    pub fa_theta: Shared<SimpleLFA<S, P>>,
-
+pub struct RecursiveLSTD<M> {
+    pub fa_theta: Shared<ScalarLFA<M>>,
     pub gamma: Parameter,
 
     c_mat: Matrix<f64>,
 }
 
-impl<S, P: Projector<S>> RecursiveLSTD<S, P> {
-    pub fn new<T: Into<Parameter>>(fa_theta: Shared<SimpleLFA<S, P>>, gamma: T) -> Self {
+impl<M: Space> RecursiveLSTD<M> {
+    pub fn new<T: Into<Parameter>>(fa_theta: Shared<ScalarLFA<M>>, gamma: T) -> Self {
         let n_features = fa_theta.borrow().projector.dim();
 
         RecursiveLSTD {
             fa_theta,
-
             gamma: gamma.into(),
 
             c_mat: Matrix::eye(n_features)*1e-6,
@@ -27,20 +25,20 @@ impl<S, P: Projector<S>> RecursiveLSTD<S, P> {
     }
 }
 
-impl<S, P: Projector<S>> RecursiveLSTD<S, P> {
+impl<M> RecursiveLSTD<M> {
     #[inline(always)]
     fn expand_phi(&self, phi: Projection) -> /* (D x 1) */ Matrix<f64> {
         phi.expanded(self.c_mat.rows()).insert_axis(Axis(1))
     }
 }
 
-impl<S, P: Projector<S>> Algorithm for RecursiveLSTD<S, P> {
+impl<M> Algorithm for RecursiveLSTD<M> {
     fn handle_terminal(&mut self) {
         self.gamma = self.gamma.step();
     }
 }
 
-impl<S, A, P: Projector<S>> OnlineLearner<S, A> for RecursiveLSTD<S, P> {
+impl<S, A, M: Projector<S>> OnlineLearner<S, A> for RecursiveLSTD<M> {
     fn handle_transition(&mut self, t: &Transition<S, A>) {
         let (s, ns) = (t.from.state(), t.to.state());
 
@@ -81,15 +79,24 @@ impl<S, A, P: Projector<S>> OnlineLearner<S, A> for RecursiveLSTD<S, P> {
     }
 }
 
-impl<S, P: Projector<S>> ValuePredictor<S> for RecursiveLSTD<S, P> {
+impl<S, M> ValuePredictor<S> for RecursiveLSTD<M>
+where
+    ScalarLFA<M>: VFunction<S>,
+{
     fn predict_v(&mut self, s: &S) -> f64 {
         self.fa_theta.borrow().evaluate(s).unwrap()
     }
 }
 
-impl<S, A, P: Projector<S>> ActionValuePredictor<S, A> for RecursiveLSTD<S, P> {}
+impl<S, A, M> ActionValuePredictor<S, A> for RecursiveLSTD<M>
+where
+    ScalarLFA<M>: VFunction<S>,
+{}
 
-impl<S, P: Projector<S>> Parameterised for RecursiveLSTD<S, P> {
+impl<M> Parameterised for RecursiveLSTD<M>
+where
+    ScalarLFA<M>: Parameterised,
+{
     fn weights(&self) -> Matrix<f64> {
         self.fa_theta.borrow().weights()
     }

--- a/src/prediction/lstd/recursive_lstd.rs
+++ b/src/prediction/lstd/recursive_lstd.rs
@@ -40,16 +40,14 @@ impl<M> Algorithm for RecursiveLSTD<M> {
 
 impl<S, A, M: Projector<S>> OnlineLearner<S, A> for RecursiveLSTD<M> {
     fn handle_transition(&mut self, t: &Transition<S, A>) {
-        let (s, ns) = (t.from.state(), t.to.state());
-
-        let phi_s = self.fa_theta.borrow().projector.project(s);
+        let phi_s = self.fa_theta.borrow().projector.project(t.from.state());
         let v = self.fa_theta.borrow().evaluate_phi(&phi_s);
         let phi_s = self.expand_phi(phi_s);
 
         let (pd, residual) = if t.terminated() {
             (phi_s.clone(), t.reward - v)
         } else {
-            let phi_ns = self.fa_theta.borrow().projector.project(ns);
+            let phi_ns = self.fa_theta.borrow().projector.project(t.to.state());
             let nv = self.fa_theta.borrow().evaluate_phi(&phi_ns);
             let phi_ns = self.expand_phi(phi_ns);
 

--- a/src/prediction/mc/gradient_mc.rs
+++ b/src/prediction/mc/gradient_mc.rs
@@ -1,18 +1,15 @@
 use crate::core::*;
 use crate::domains::Transition;
 use crate::fa::{Parameterised, VFunction};
-use std::marker::PhantomData;
 
-pub struct GradientMC<S, V> {
+pub struct GradientMC<V> {
     pub v_func: Shared<V>,
 
     pub alpha: Parameter,
     pub gamma: Parameter,
-
-    phantom: PhantomData<S>,
 }
 
-impl<S, V: VFunction<S>> GradientMC<S, V> {
+impl<V> GradientMC<V> {
     pub fn new<T1, T2>(v_func: Shared<V>, alpha: T1, gamma: T2) -> Self
     where
         T1: Into<Parameter>,
@@ -23,20 +20,18 @@ impl<S, V: VFunction<S>> GradientMC<S, V> {
 
             alpha: alpha.into(),
             gamma: gamma.into(),
-
-            phantom: PhantomData,
         }
     }
 }
 
-impl<S, V: VFunction<S>> Algorithm for GradientMC<S, V> {
+impl<V> Algorithm for GradientMC<V> {
     fn handle_terminal(&mut self) {
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
     }
 }
 
-impl<S, A, V: VFunction<S>> BatchLearner<S, A> for GradientMC<S, V> {
+impl<S, A, V: VFunction<S>> BatchLearner<S, A> for GradientMC<V> {
     fn handle_batch(&mut self, batch: &[Transition<S, A>]) {
         let mut sum = 0.0;
 
@@ -50,15 +45,15 @@ impl<S, A, V: VFunction<S>> BatchLearner<S, A> for GradientMC<S, V> {
     }
 }
 
-impl<S, V: VFunction<S>> ValuePredictor<S> for GradientMC<S, V> {
+impl<S, V: VFunction<S>> ValuePredictor<S> for GradientMC<V> {
     fn predict_v(&mut self, s: &S) -> f64 {
         self.v_func.borrow().evaluate(s).unwrap()
     }
 }
 
-impl<S, A, V: VFunction<S>> ActionValuePredictor<S, A> for GradientMC<S, V> {}
+impl<S, A, V: VFunction<S>> ActionValuePredictor<S, A> for GradientMC<V> {}
 
-impl<S, V: Parameterised> Parameterised for GradientMC<S, V> {
+impl<V: Parameterised> Parameterised for GradientMC<V> {
     fn weights(&self) -> Matrix<f64> {
         self.v_func.borrow().weights()
     }

--- a/src/prediction/td/td.rs
+++ b/src/prediction/td/td.rs
@@ -2,18 +2,15 @@ use crate::core::*;
 use crate::domains::Transition;
 use crate::fa::{Parameterised, VFunction};
 use crate::geometry::Matrix;
-use std::marker::PhantomData;
 
-pub struct TD<S, V> {
+pub struct TD<V> {
     pub v_func: Shared<V>,
 
     pub alpha: Parameter,
     pub gamma: Parameter,
-
-    phantom: PhantomData<S>,
 }
 
-impl<S, V: VFunction<S>> TD<S, V> {
+impl<V> TD<V> {
     pub fn new<T1, T2>(v_func: Shared<V>, alpha: T1, gamma: T2) -> Self
     where
         T1: Into<Parameter>,
@@ -24,20 +21,18 @@ impl<S, V: VFunction<S>> TD<S, V> {
 
             alpha: alpha.into(),
             gamma: gamma.into(),
-
-            phantom: PhantomData,
         }
     }
 }
 
-impl<S, V: VFunction<S>> Algorithm for TD<S, V> {
+impl<V> Algorithm for TD<V> {
     fn handle_terminal(&mut self) {
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
     }
 }
 
-impl<S, A, V: VFunction<S>> OnlineLearner<S, A> for TD<S, V> {
+impl<S, A, V: VFunction<S>> OnlineLearner<S, A> for TD<V> {
     fn handle_transition(&mut self, t: &Transition<S, A>) {
         let s = t.from.state();
         let v = self.predict_v(s);
@@ -52,13 +47,13 @@ impl<S, A, V: VFunction<S>> OnlineLearner<S, A> for TD<S, V> {
     }
 }
 
-impl<S, V: VFunction<S>> ValuePredictor<S> for TD<S, V> {
+impl<S, V: VFunction<S>> ValuePredictor<S> for TD<V> {
     fn predict_v(&mut self, s: &S) -> f64 { self.v_func.borrow().evaluate(s).unwrap() }
 }
 
-impl<S, A, V: VFunction<S>> ActionValuePredictor<S, A> for TD<S, V> {}
+impl<S, A, V: VFunction<S>> ActionValuePredictor<S, A> for TD<V> {}
 
-impl<S, V: Parameterised> Parameterised for TD<S, V> {
+impl<V: Parameterised> Parameterised for TD<V> {
     fn weights(&self) -> Matrix<f64> {
         self.v_func.borrow().weights()
     }


### PR DESCRIPTION
In the vast majority of cases we use a type parameter S to define the representation of state. However, in many cases, the underlying code for function approximation etc supports many different types of inputs. In other words, there is no need to restrict ourselves upon construction to a single state type.

This cull removes the S types wherever possible by removing type constraints on the structs themselves. This is good practice anyway as it allows us to build more general algorithms and only define the requirements inside our impl blocks.