### PR TITLE
Replace Shared with dedicated type

### DIFF
--- a/examples/sarsa_lambda.rs
+++ b/examples/sarsa_lambda.rs
@@ -20,17 +20,17 @@ fn main() {
         // Build the linear value function using a fourier basis projection and the
         // appropriate eligibility trace.
         let bases = Fourier::from_space(3, domain.state_space());
-        let trace = Trace::replacing(0.7, bases.dim());
+        let trace = Trace::replacing(0.5, bases.dim());
         let q_func = make_shared(LFA::vector_output(bases, n_actions));
 
         // Build a stochastic behaviour policy with exponential epsilon.
         let policy = make_shared(EpsilonGreedy::new(
             Greedy::new(q_func.clone()),
             Random::new(n_actions),
-            Parameter::exponential(0.5, 0.001, 0.9),
+            Parameter::exponential(0.7, 0.001, 0.99),
         ));
 
-        SARSALambda::new(q_func, policy, trace, 0.001, 0.99)
+        SARSALambda::new(q_func, policy, trace, 0.005, 1.0)
     };
 
     let logger = logging::root(logging::stdout());

--- a/src/control/actor_critic/nac.rs
+++ b/src/control/actor_critic/nac.rs
@@ -45,14 +45,14 @@ where
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
         self.critic.borrow_mut().handle_transition(t);
         self.policy.borrow_mut().update_raw(
-            self.alpha.value() * self.critic.borrow().weights()
+            self.alpha.value() * self.critic.weights()
         );
     }
 
     fn handle_sequence(&mut self, seq: &[Transition<S, P::Action>]) {
         self.critic.borrow_mut().handle_sequence(seq);
         self.policy.borrow_mut().update_raw(
-            self.alpha.value() * self.critic.borrow().weights()
+            self.alpha.value() * self.critic.weights()
         );
     }
 }

--- a/src/control/gtd/greedy_gq.rs
+++ b/src/control/gtd/greedy_gq.rs
@@ -63,13 +63,13 @@ where
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
         let s = t.from.state();
-        let dim = self.fa_theta.borrow().projector.dim();
-        let phi_s = self.fa_w.borrow().projector.project(s);
+        let dim = self.fa_theta.projector.dim();
+        let phi_s = self.fa_w.projector.project(s);
 
-        let estimate = self.fa_w.borrow().evaluate_phi(&phi_s);
+        let estimate = self.fa_w.evaluate_phi(&phi_s);
 
         if t.terminated() {
-            let residual = t.reward - self.fa_theta.borrow().evaluate_action_phi(&phi_s, t.action);
+            let residual = t.reward - self.fa_theta.evaluate_action_phi(&phi_s, t.action);
 
             self.fa_w.borrow_mut().update_phi(
                 &phi_s,
@@ -83,12 +83,12 @@ where
         } else {
             let ns = t.from.state();
             let na = self.sample_target(ns);
-            let phi_ns = self.fa_w.borrow().projector.project(ns);
+            let phi_ns = self.fa_w.projector.project(ns);
 
             let residual =
                 t.reward
-                + self.gamma.value() * self.fa_theta.borrow().evaluate_action_phi(&phi_ns, na)
-                - self.fa_theta.borrow().evaluate_action_phi(&phi_s, t.action);
+                + self.gamma.value() * self.fa_theta.evaluate_action_phi(&phi_ns, na)
+                - self.fa_theta.evaluate_action_phi(&phi_s, t.action);
 
             let update_q = residual * phi_s.clone().expanded(dim)
                 - estimate * self.gamma.value() * phi_ns.expanded(dim);
@@ -122,11 +122,11 @@ where
     P: FinitePolicy<S>,
 {
     fn predict_qs(&mut self, s: &S) -> Vector<f64> {
-        self.fa_theta.borrow().evaluate(s).unwrap()
+        self.fa_theta.evaluate(s).unwrap()
     }
 
     fn predict_qsa(&mut self, s: &S, a: P::Action) -> f64 {
-        self.fa_theta.borrow().evaluate_action(&s, a)
+        self.fa_theta.evaluate_action(&s, a)
     }
 }
 
@@ -142,6 +142,6 @@ where
 
 impl<M, P> Parameterised for GreedyGQ<M, P> {
     fn weights(&self) -> Matrix<f64> {
-        self.fa_theta.borrow().weights()
+        self.fa_theta.weights()
     }
 }

--- a/src/control/mc/baseline_reinforce.rs
+++ b/src/control/mc/baseline_reinforce.rs
@@ -74,6 +74,6 @@ impl<S, B, P: ParameterisedPolicy<S>> Controller<S, P::Action> for BaselineREINF
 
 impl<B, P: Parameterised> Parameterised for BaselineREINFORCE<B, P> {
     fn weights(&self) -> Matrix<f64> {
-        self.policy.borrow().weights()
+        self.policy.weights()
     }
 }

--- a/src/control/mc/reinforce.rs
+++ b/src/control/mc/reinforce.rs
@@ -65,6 +65,6 @@ impl<S, P: ParameterisedPolicy<S>> Controller<S, P::Action> for REINFORCE<P> {
 
 impl<P: Parameterised> Parameterised for REINFORCE<P> {
     fn weights(&self) -> Matrix<f64> {
-        self.policy.borrow().weights()
+        self.policy.weights()
     }
 }

--- a/src/control/td/expected_sarsa.rs
+++ b/src/control/td/expected_sarsa.rs
@@ -89,16 +89,16 @@ where
     P: FinitePolicy<S>,
 {
     fn predict_qs(&mut self, s: &S) -> Vector<f64> {
-        self.q_func.borrow().evaluate(s).unwrap()
+        self.q_func.evaluate(s).unwrap()
     }
 
     fn predict_qsa(&mut self, s: &S, a: P::Action) -> f64 {
-        self.q_func.borrow().evaluate_action(&s, a)
+        self.q_func.evaluate_action(&s, a)
     }
 }
 
 impl<Q: Parameterised, P> Parameterised for ExpectedSARSA<Q, P> {
     fn weights(&self) -> Matrix<f64> {
-        self.q_func.borrow().weights()
+        self.q_func.weights()
     }
 }

--- a/src/control/td/pal.rs
+++ b/src/control/td/pal.rs
@@ -101,16 +101,16 @@ where
     P: Policy<S, Action = <Greedy<Q> as Policy<S>>::Action>,
 {
     fn predict_qs(&mut self, s: &S) -> Vector<f64> {
-        self.q_func.borrow().evaluate(s).unwrap()
+        self.q_func.evaluate(s).unwrap()
     }
 
     fn predict_qsa(&mut self, s: &S, a: P::Action) -> f64 {
-        self.q_func.borrow().evaluate_action(&s, a)
+        self.q_func.evaluate_action(&s, a)
     }
 }
 
 impl<Q: Parameterised, P> Parameterised for PAL<Q, P> {
     fn weights(&self) -> Matrix<f64> {
-        self.q_func.borrow().weights()
+        self.q_func.weights()
     }
 }

--- a/src/control/td/q_lambda.rs
+++ b/src/control/td/q_lambda.rs
@@ -65,11 +65,11 @@ where
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
         let s = t.from.state();
-        let phi_s = self.fa_theta.borrow().projector.project(s);
-        let qsa = self.fa_theta.borrow().evaluate_action_phi(&phi_s, t.action);
+        let phi_s = self.fa_theta.projector.project(s);
+        let qsa = self.fa_theta.evaluate_action_phi(&phi_s, t.action);
 
         // Update trace:
-        let n_bases = self.fa_theta.borrow().projector.dim();
+        let n_bases = self.fa_theta.projector.dim();
         let decay_rate = if t.action == self.target.sample(s) {
             self.trace.lambda.value() * self.gamma.value()
         } else {
@@ -88,7 +88,7 @@ where
         } else {
             let ns = t.to.state();
             let na = self.target.sample(&ns);
-            let nqsna = self.fa_theta.borrow().evaluate_action(ns, na);
+            let nqsna = self.fa_theta.evaluate_action(ns, na);
 
             t.reward + self.gamma * nqsna - qsa
         };
@@ -128,16 +128,16 @@ where
     P: Policy<S, Action = <Greedy<F> as Policy<S>>::Action>,
 {
     fn predict_qs(&mut self, s: &S) -> Vector<f64> {
-        self.fa_theta.borrow().evaluate(s).unwrap()
+        self.fa_theta.evaluate(s).unwrap()
     }
 
     fn predict_qsa(&mut self, s: &S, a: P::Action) -> f64 {
-        self.fa_theta.borrow().evaluate_action(&s, a)
+        self.fa_theta.evaluate_action(&s, a)
     }
 }
 
 impl<F: Parameterised, P> Parameterised for QLambda<F, P> {
     fn weights(&self) -> Matrix<f64> {
-        self.fa_theta.borrow().weights()
+        self.fa_theta.weights()
     }
 }

--- a/src/control/td/q_learning.rs
+++ b/src/control/td/q_learning.rs
@@ -98,16 +98,16 @@ where
     P: Policy<S, Action = <Greedy<Q> as Policy<S>>::Action>,
 {
     fn predict_qs(&mut self, s: &S) -> Vector<f64> {
-        self.q_func.borrow().evaluate(s).unwrap()
+        self.q_func.evaluate(s).unwrap()
     }
 
     fn predict_qsa(&mut self, s: &S, a: P::Action) -> f64 {
-        self.q_func.borrow().evaluate_action(&s, a)
+        self.q_func.evaluate_action(&s, a)
     }
 }
 
 impl<Q: Parameterised, P> Parameterised for QLearning<Q, P> {
     fn weights(&self) -> Matrix<f64> {
-        self.q_func.borrow().weights()
+        self.q_func.weights()
     }
 }

--- a/src/control/td/q_sigma.rs
+++ b/src/control/td/q_sigma.rs
@@ -89,8 +89,7 @@ impl<S, Q: QFunction<S>, P> QSigma<S, Q, P> {
             rho *= 1.0 - b1.sigma + b1.sigma * b1.pi / b1.mu;
         }
 
-        let qsa = self.q_func.borrow()
-            .evaluate_action(&self.backup[0].s, self.backup[0].a);
+        let qsa = self.q_func.evaluate_action(&self.backup[0].s, self.backup[0].a);
 
         self.q_func.borrow_mut().update_action(
             &self.backup[0].s,
@@ -153,7 +152,7 @@ where
         } else {
             let ns = t.to.state();
             let na = self.sample_behaviour(&ns);
-            let nqs = self.q_func.borrow().evaluate(&ns).unwrap();
+            let nqs = self.q_func.evaluate(&ns).unwrap();
             let nqa = nqs[na];
 
             let pi = self.target.probabilities(&ns);
@@ -206,16 +205,16 @@ where
     P: Policy<S, Action = <Greedy<Q> as Policy<S>>::Action>,
 {
     fn predict_qs(&mut self, s: &S) -> Vector<f64> {
-        self.q_func.borrow().evaluate(s).unwrap()
+        self.q_func.evaluate(s).unwrap()
     }
 
     fn predict_qsa(&mut self, s: &S, a: P::Action) -> f64 {
-        self.q_func.borrow().evaluate_action(&s, a)
+        self.q_func.evaluate_action(&s, a)
     }
 }
 
 impl<S, Q: Parameterised, P> Parameterised for QSigma<S, Q, P> {
     fn weights(&self) -> Matrix<f64> {
-        self.q_func.borrow().weights()
+        self.q_func.weights()
     }
 }

--- a/src/control/td/sarsa.rs
+++ b/src/control/td/sarsa.rs
@@ -51,13 +51,13 @@ where
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
         let s = t.from.state();
-        let qsa = self.q_func.borrow().evaluate_action(s, t.action);
+        let qsa = self.q_func.evaluate_action(s, t.action);
         let residual = if t.terminated() {
             t.reward - qsa
         } else {
             let ns = t.to.state();
             let na = self.policy.borrow_mut().sample(ns);
-            let nqsna = self.q_func.borrow().evaluate_action(ns, na);
+            let nqsna = self.q_func.evaluate_action(ns, na);
 
             t.reward + self.gamma * nqsna - qsa
         };
@@ -92,16 +92,16 @@ where
     P: FinitePolicy<S>,
 {
     fn predict_qs(&mut self, s: &S) -> Vector<f64> {
-        self.q_func.borrow().evaluate(s).unwrap()
+        self.q_func.evaluate(s).unwrap()
     }
 
     fn predict_qsa(&mut self, s: &S, a: P::Action) -> f64 {
-        self.q_func.borrow().evaluate_action(&s, a)
+        self.q_func.evaluate_action(&s, a)
     }
 }
 
 impl<Q: Parameterised, P> Parameterised for SARSA<Q, P> {
     fn weights(&self) -> Matrix<f64> {
-        self.q_func.borrow().weights()
+        self.q_func.weights()
     }
 }

--- a/src/control/td/sarsa_lambda.rs
+++ b/src/control/td/sarsa_lambda.rs
@@ -69,11 +69,11 @@ where
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
         let s = t.from.state();
-        let phi_s = self.fa_theta.borrow().projector.project(s);
-        let qsa = self.fa_theta.borrow().evaluate_action_phi(&phi_s, t.action);
+        let phi_s = self.fa_theta.projector.project(s);
+        let qsa = self.fa_theta.evaluate_action_phi(&phi_s, t.action);
 
         // Update trace:
-        let n_bases = self.fa_theta.borrow().projector.dim();
+        let n_bases = self.fa_theta.projector.dim();
 
         self.update_trace(phi_s.expanded(n_bases));
 
@@ -86,7 +86,7 @@ where
         } else {
             let ns = t.to.state();
             let na = self.policy.borrow_mut().sample(ns);
-            let nqsna = self.fa_theta.borrow().evaluate_action(ns, na);
+            let nqsna = self.fa_theta.evaluate_action(ns, na);
 
             t.reward + self.gamma * nqsna - qsa
         };
@@ -125,16 +125,16 @@ where
     P: FinitePolicy<S>,
 {
     fn predict_qs(&mut self, s: &S) -> Vector<f64> {
-        self.fa_theta.borrow().evaluate(s).unwrap()
+        self.fa_theta.evaluate(s).unwrap()
     }
 
     fn predict_qsa(&mut self, s: &S, a: P::Action) -> f64 {
-        self.fa_theta.borrow().evaluate_action(&s, a)
+        self.fa_theta.evaluate_action(&s, a)
     }
 }
 
 impl<F: Parameterised, P> Parameterised for SARSALambda<F, P> {
     fn weights(&self) -> Matrix<f64> {
-        self.fa_theta.borrow().weights()
+        self.fa_theta.weights()
     }
 }

--- a/src/control/totd/to_q_lambda.rs
+++ b/src/control/totd/to_q_lambda.rs
@@ -74,10 +74,10 @@ where
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
         let s = t.from.state();
-        let phi_s = self.q_func.borrow().projector.project(s);
+        let phi_s = self.q_func.projector.project(s);
 
         // Update traces:
-        let n_bases = self.q_func.borrow().projector.dim();
+        let n_bases = self.q_func.projector.dim();
         let update_rate = self.trace.lambda.value() * self.gamma.value();
         let decay_rate = if t.action == self.sample_target(s) {
             update_rate
@@ -89,7 +89,7 @@ where
 
         // Update weight vectors:
         let z = self.trace.get();
-        let qsa = self.q_func.borrow().evaluate_action_phi(&phi_s, t.action);
+        let qsa = self.q_func.evaluate_action_phi(&phi_s, t.action);
         let q_old = self.q_old;
 
         let residual = if t.terminated() {
@@ -101,7 +101,7 @@ where
         } else {
             let ns = t.to.state();
             let na = self.sample_behaviour(ns);
-            let nqsna = self.q_func.borrow().evaluate_action(ns, na);
+            let nqsna = self.q_func.evaluate_action(ns, na);
 
             self.q_old = nqsna;
 
@@ -152,16 +152,16 @@ where
     P: Policy<S, Action = <Greedy<VectorLFA<M>> as Policy<S>>::Action>,
 {
     fn predict_qs(&mut self, s: &S) -> Vector<f64> {
-        self.q_func.borrow().evaluate(s).unwrap()
+        self.q_func.evaluate(s).unwrap()
     }
 
     fn predict_qsa(&mut self, s: &S, a: P::Action) -> f64 {
-        self.q_func.borrow().evaluate_action(&s, a)
+        self.q_func.evaluate_action(&s, a)
     }
 }
 
 impl<M, P> Parameterised for TOQLambda<M, P> {
     fn weights(&self) -> Matrix<f64> {
-        self.q_func.borrow().weights()
+        self.q_func.weights()
     }
 }

--- a/src/control/totd/to_sarsa_lambda.rs
+++ b/src/control/totd/to_sarsa_lambda.rs
@@ -70,17 +70,17 @@ where
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
         let s = t.from.state();
-        let phi_s = self.q_func.borrow().projector.project(s);
+        let phi_s = self.q_func.projector.project(s);
 
         // Update traces:
-        let n_bases = self.q_func.borrow().projector.dim();
+        let n_bases = self.q_func.projector.dim();
         let decay_rate = self.trace.lambda.value() * self.gamma.value();
 
         self.update_traces(phi_s.clone().expanded(n_bases), decay_rate);
 
         // Update weight vectors:
         let z = self.trace.get();
-        let qsa = self.q_func.borrow().evaluate_action_phi(&phi_s, t.action);
+        let qsa = self.q_func.evaluate_action_phi(&phi_s, t.action);
         let q_old = self.q_old;
 
         let residual = if t.terminated() {
@@ -92,7 +92,7 @@ where
         } else {
             let ns = t.to.state();
             let na = self.sample_behaviour(ns);
-            let nqsna = self.q_func.borrow().evaluate_action(ns, na);
+            let nqsna = self.q_func.evaluate_action(ns, na);
 
             self.q_old = nqsna;
 
@@ -141,16 +141,16 @@ where
     P: FinitePolicy<S>,
 {
     fn predict_qs(&mut self, s: &S) -> Vector<f64> {
-        self.q_func.borrow().evaluate(s).unwrap()
+        self.q_func.evaluate(s).unwrap()
     }
 
     fn predict_qsa(&mut self, s: &S, a: P::Action) -> f64 {
-        self.q_func.borrow().evaluate_action(&s, a)
+        self.q_func.evaluate_action(&s, a)
     }
 }
 
 impl<M, P> Parameterised for TOSARSALambda<M, P> {
     fn weights(&self) -> Matrix<f64> {
-        self.q_func.borrow().weights()
+        self.q_func.weights()
     }
 }

--- a/src/core/memory.rs
+++ b/src/core/memory.rs
@@ -1,6 +1,55 @@
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::{
+    cell::{RefCell, Ref, RefMut},
+    fmt,
+    ops::Deref,
+    rc::Rc,
+};
 
-pub type Shared<T> = Rc<RefCell<T>>;
+pub struct Shared<T>(Rc<RefCell<T>>);
 
-pub fn make_shared<T>(t: T) -> Shared<T> { Rc::new(RefCell::new(t)) }
+impl<T> Shared<T> {
+    pub fn new(t: T) -> Shared<T> {
+        make_shared(t)
+    }
+
+    pub fn borrow(&self) -> Ref<T> {
+        self.0.borrow()
+    }
+
+    pub fn borrow_mut(&self) -> RefMut<T> {
+        self.0.borrow_mut()
+    }
+
+    pub fn as_ptr(&self) -> *mut T {
+        self.0.as_ptr()
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for Shared<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Shared<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.deref())
+    }
+}
+
+impl<'a, T> Deref for Shared<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        unsafe { self.as_ptr().as_ref().unwrap() }
+    }
+}
+
+impl<T> Clone for Shared<T> {
+    fn clone(&self) -> Shared<T> {
+        Shared(self.0.clone())
+    }
+}
+
+pub fn make_shared<T>(t: T) -> Shared<T> { Shared(Rc::new(RefCell::new(t))) }

--- a/src/policies/fixed/boltzmann.rs
+++ b/src/policies/fixed/boltzmann.rs
@@ -43,7 +43,7 @@ impl<S, Q: QFunction<S>> Policy<S> for Boltzmann<Q> {
 
 impl<S, Q: QFunction<S>> FinitePolicy<S> for Boltzmann<Q> {
     fn n_actions(&self) -> usize {
-        self.q_func.borrow().n_outputs()
+        self.q_func.n_outputs()
     }
 
     fn probabilities(&mut self, s: &S) -> Vector<f64> {
@@ -52,7 +52,6 @@ impl<S, Q: QFunction<S>> FinitePolicy<S> for Boltzmann<Q> {
         let mut z = 0.0;
         let ws: Vec<f64> = self
             .q_func
-            .borrow()
             .evaluate(s)
             .unwrap()
             .into_iter()

--- a/src/policies/fixed/greedy.rs
+++ b/src/policies/fixed/greedy.rs
@@ -16,7 +16,7 @@ impl<S, Q: QFunction<S>> Policy<S> for Greedy<Q> {
     type Action = usize;
 
     fn sample(&mut self, s: &S) -> usize {
-        let qs = self.0.borrow().evaluate(s).unwrap();
+        let qs = self.0.evaluate(s).unwrap();
         let maxima = argmaxima(qs.as_slice().unwrap()).1;
 
         if maxima.len() == 1 {
@@ -33,11 +33,11 @@ impl<S, Q: QFunction<S>> Policy<S> for Greedy<Q> {
 
 impl<S, Q: QFunction<S>> FinitePolicy<S> for Greedy<Q> {
     fn n_actions(&self) -> usize {
-        self.0.borrow().n_outputs()
+        self.0.n_outputs()
     }
 
     fn probabilities(&mut self, s: &S) -> Vector<f64> {
-        let qs = self.0.borrow().evaluate(s).unwrap();
+        let qs = self.0.evaluate(s).unwrap();
         let mut ps = vec![0.0; qs.len()];
 
         let maxima = argmaxima(qs.as_slice().unwrap()).1;

--- a/src/policies/fixed/truncated_boltzmann.rs
+++ b/src/policies/fixed/truncated_boltzmann.rs
@@ -45,7 +45,7 @@ impl<S, Q: QFunction<S>> Policy<S> for TruncatedBoltzmann<Q> {
 
 impl<S, Q: QFunction<S>> FinitePolicy<S> for TruncatedBoltzmann<Q> {
     fn n_actions(&self) -> usize {
-        self.q_func.borrow().n_outputs()
+        self.q_func.n_outputs()
     }
 
     fn probabilities(&mut self, s: &S) -> Vector<f64> {
@@ -54,7 +54,6 @@ impl<S, Q: QFunction<S>> FinitePolicy<S> for TruncatedBoltzmann<Q> {
         let mut z = 0.0;
         let ws: Vec<f64> = self
             .q_func
-            .borrow()
             .evaluate(s)
             .unwrap()
             .into_iter()

--- a/src/prediction/gtd/tdc.rs
+++ b/src/prediction/gtd/tdc.rs
@@ -25,7 +25,7 @@ impl<M: Space> TDC<M> {
         T2: Into<Parameter>,
         T3: Into<Parameter>,
     {
-        if fa_theta.borrow().projector.dim() != fa_w.borrow().projector.dim() {
+        if fa_theta.projector.dim() != fa_w.projector.dim() {
             panic!("fa_theta and fa_w must be equivalent function approximators.")
         }
 
@@ -50,20 +50,20 @@ impl<M> Algorithm for TDC<M> {
 
 impl<S, A, M: Projector<S>> OnlineLearner<S, A> for TDC<M> {
     fn handle_transition(&mut self, t: &Transition<S, A>) {
-        let (phi_s, phi_ns) = t.map_states(|s| self.fa_theta.borrow().projector.project(s));
+        let (phi_s, phi_ns) = t.map_states(|s| self.fa_theta.projector.project(s));
 
-        let v = self.fa_theta.borrow().evaluate_phi(&phi_s);
+        let v = self.fa_theta.evaluate_phi(&phi_s);
 
-        let td_estimate = self.fa_w.borrow().evaluate_phi(&phi_s);
+        let td_estimate = self.fa_w.evaluate_phi(&phi_s);
         let td_error = if t.terminated() {
             t.reward - v
         } else {
-            t.reward + self.gamma * self.fa_theta.borrow().evaluate_phi(&phi_ns) - v
+            t.reward + self.gamma * self.fa_theta.evaluate_phi(&phi_ns) - v
         };
 
         self.fa_w.borrow_mut().update_phi(&phi_s, self.beta * (td_error - td_estimate));
 
-        let dim = self.fa_theta.borrow().projector.dim();
+        let dim = self.fa_theta.projector.dim();
         let phi =
             td_error * phi_s.expanded(dim) -
             td_estimate * self.gamma.value() * phi_ns.expanded(dim);
@@ -77,7 +77,7 @@ where
     ScalarLFA<M>: VFunction<S>,
 {
     fn predict_v(&mut self, s: &S) -> f64 {
-        self.fa_theta.borrow().evaluate(s).unwrap()
+        self.fa_theta.evaluate(s).unwrap()
     }
 }
 
@@ -91,6 +91,6 @@ where
     ScalarLFA<M>: Parameterised,
 {
     fn weights(&self) -> Matrix<f64> {
-        self.fa_theta.borrow().weights()
+        self.fa_theta.weights()
     }
 }

--- a/src/prediction/lstd/ilstd.rs
+++ b/src/prediction/lstd/ilstd.rs
@@ -23,7 +23,7 @@ impl<M: Space> iLSTD<M> {
         where T1: Into<Parameter>,
               T2: Into<Parameter>
     {
-        let n_features = fa_theta.borrow().projector.dim();
+        let n_features = fa_theta.projector.dim();
 
         iLSTD {
             fa_theta,
@@ -68,7 +68,7 @@ impl<M> Algorithm for iLSTD<M> {
 impl<S, A, M: Projector<S>> OnlineLearner<S, A> for iLSTD<M> {
     fn handle_transition(&mut self, t: &Transition<S, A>) {
         // (D x 1)
-        let phi_s = self.fa_theta.borrow().projector
+        let phi_s = self.fa_theta.projector
             .project(t.from.state())
             .expanded(self.a.rows());
 
@@ -76,7 +76,7 @@ impl<S, A, M: Projector<S>> OnlineLearner<S, A> for iLSTD<M> {
         let pd = if t.terminated() {
             phi_s.clone().insert_axis(Axis(0))
         } else {
-            let phi_ns = self.fa_theta.borrow().projector
+            let phi_ns = self.fa_theta.projector
                 .project(t.to.state())
                 .expanded(self.a.rows());
 
@@ -89,7 +89,7 @@ impl<S, A, M: Projector<S>> OnlineLearner<S, A> for iLSTD<M> {
         self.a += &delta_a;
 
         self.mu.scaled_add(t.reward, &phi_s);
-        self.mu -= &delta_a.dot(&self.fa_theta.borrow().approximator.weights);
+        self.mu -= &delta_a.dot(&self.fa_theta.approximator.weights);
 
         self.solve();
     }
@@ -100,7 +100,7 @@ where
     ScalarLFA<M>: VFunction<S>,
 {
     fn predict_v(&mut self, s: &S) -> f64 {
-        self.fa_theta.borrow().evaluate(s).unwrap()
+        self.fa_theta.evaluate(s).unwrap()
     }
 }
 
@@ -114,6 +114,6 @@ where
     ScalarLFA<M>: Parameterised,
 {
     fn weights(&self) -> Matrix<f64> {
-        self.fa_theta.borrow().weights()
+        self.fa_theta.weights()
     }
 }

--- a/src/prediction/lstd/lambda_lspe.rs
+++ b/src/prediction/lstd/lambda_lspe.rs
@@ -26,7 +26,7 @@ impl<M: Space> LambdaLSPE<M> {
         T2: Into<Parameter>,
         T3: Into<Parameter>,
     {
-        let n_features = fa_theta.borrow().projector.dim();
+        let n_features = fa_theta.projector.dim();
 
         LambdaLSPE {
             fa_theta,
@@ -45,7 +45,7 @@ impl<M: Space> LambdaLSPE<M> {
 impl<M> LambdaLSPE<M> {
     #[inline(always)]
     fn compute_v(&self, phi: &Vector<f64>) -> f64 {
-        self.fa_theta.borrow().approximator.weights.dot(phi)
+        self.fa_theta.approximator.weights.dot(phi)
     }
 
     fn solve(&mut self) {
@@ -74,7 +74,7 @@ impl<M> Algorithm for LambdaLSPE<M> {
 impl<S, A, M: Projector<S>> BatchLearner<S, A> for LambdaLSPE<M> {
     fn handle_batch(&mut self, batch: &[Transition<S, A>]) {
         batch.into_iter().rev().for_each(|ref t| {
-            let phi_s = self.fa_theta.borrow().projector
+            let phi_s = self.fa_theta.projector
                 .project(t.from.state())
                 .expanded(self.a.rows());
             let v = self.compute_v(&phi_s);
@@ -86,7 +86,7 @@ impl<S, A, M: Projector<S>> BatchLearner<S, A> for LambdaLSPE<M> {
                 self.a += &phi_s.clone().insert_axis(Axis(1)).dot(&(phi_s.insert_axis(Axis(0))));
 
             } else {
-                let phi_ns = self.fa_theta.borrow().projector
+                let phi_ns = self.fa_theta.projector
                     .project(t.to.state())
                     .expanded(self.a.rows());
                 let residual = t.reward + self.gamma * self.compute_v(&phi_ns) - v;
@@ -107,7 +107,7 @@ where
     ScalarLFA<M>: VFunction<S>,
 {
     fn predict_v(&mut self, s: &S) -> f64 {
-        self.fa_theta.borrow().evaluate(s).unwrap()
+        self.fa_theta.evaluate(s).unwrap()
     }
 }
 
@@ -121,6 +121,6 @@ where
     ScalarLFA<M>: Parameterised,
 {
     fn weights(&self) -> Matrix<f64> {
-        self.fa_theta.borrow().weights()
+        self.fa_theta.weights()
     }
 }

--- a/src/prediction/lstd/lstd.rs
+++ b/src/prediction/lstd/lstd.rs
@@ -17,7 +17,7 @@ pub struct LSTD<M> {
 
 impl<M: Space> LSTD<M> {
     pub fn new<T: Into<Parameter>>(fa_theta: Shared<ScalarLFA<M>>, gamma: T) -> Self {
-        let n_features = fa_theta.borrow().projector.dim();
+        let n_features = fa_theta.projector.dim();
 
         LSTD {
             fa_theta,
@@ -39,13 +39,13 @@ impl<M> Algorithm for LSTD<M> {
 impl<S, A, M: Projector<S>> BatchLearner<S, A> for LSTD<M> {
     fn handle_batch(&mut self, ts: &[Transition<S, A>]) {
         ts.into_iter().for_each(|ref t| {
-            let phi_s = self.fa_theta.borrow().projector
+            let phi_s = self.fa_theta.projector
                 .project(t.from.state())
                 .expanded(self.a.rows());
             let pd = if t.terminated() {
                 phi_s.clone()
             } else {
-                let phi_ns = self.fa_theta.borrow().projector
+                let phi_ns = self.fa_theta.projector
                     .project(t.to.state())
                     .expanded(self.a.rows());
 
@@ -74,7 +74,7 @@ where
     ScalarLFA<M>: VFunction<S>,
 {
     fn predict_v(&mut self, s: &S) -> f64 {
-        self.fa_theta.borrow().evaluate(s).unwrap()
+        self.fa_theta.evaluate(s).unwrap()
     }
 }
 
@@ -88,6 +88,6 @@ where
     ScalarLFA<M>: Parameterised
 {
     fn weights(&self) -> Matrix<f64> {
-        self.fa_theta.borrow().weights()
+        self.fa_theta.weights()
     }
 }

--- a/src/prediction/lstd/lstd_lambda.rs
+++ b/src/prediction/lstd/lstd_lambda.rs
@@ -19,7 +19,7 @@ pub struct LSTDLambda<M> {
 impl<M: Space> LSTDLambda<M> {
     pub fn new<T: Into<Parameter>>(fa_theta: Shared<ScalarLFA<M>>,
                                    trace: Trace, gamma: T) -> Self {
-        let n_features = fa_theta.borrow().projector.dim();
+        let n_features = fa_theta.projector.dim();
 
         LSTDLambda {
             fa_theta,
@@ -68,7 +68,7 @@ impl<M> Algorithm for LSTDLambda<M> {
 impl<S, A, M: Projector<S>> BatchLearner<S, A> for LSTDLambda<M> {
     fn handle_batch(&mut self, ts: &[Transition<S, A>]) {
         ts.into_iter().for_each(|t| {
-            let phi_s = self.fa_theta.borrow().projector
+            let phi_s = self.fa_theta.projector
                 .project(t.from.state())
                 .expanded(self.a.rows());
             let z = self.update_trace(&phi_s);
@@ -80,7 +80,7 @@ impl<S, A, M: Projector<S>> BatchLearner<S, A> for LSTDLambda<M> {
 
                 phi_s
             } else {
-                let phi_ns = self.fa_theta.borrow().projector
+                let phi_ns = self.fa_theta.projector
                     .project(t.to.state())
                     .expanded(self.a.rows());
 
@@ -99,7 +99,7 @@ where
     ScalarLFA<M>: VFunction<S>,
 {
     fn predict_v(&mut self, s: &S) -> f64 {
-        self.fa_theta.borrow().evaluate(s).unwrap()
+        self.fa_theta.evaluate(s).unwrap()
     }
 }
 
@@ -113,6 +113,6 @@ where
     ScalarLFA<M>: Parameterised,
 {
     fn weights(&self) -> Matrix<f64> {
-        self.fa_theta.borrow().weights()
+        self.fa_theta.weights()
     }
 }

--- a/src/prediction/lstd/recursive_lstd.rs
+++ b/src/prediction/lstd/recursive_lstd.rs
@@ -14,7 +14,7 @@ pub struct RecursiveLSTD<M> {
 
 impl<M: Space> RecursiveLSTD<M> {
     pub fn new<T: Into<Parameter>>(fa_theta: Shared<ScalarLFA<M>>, gamma: T) -> Self {
-        let n_features = fa_theta.borrow().projector.dim();
+        let n_features = fa_theta.projector.dim();
 
         RecursiveLSTD {
             fa_theta,
@@ -40,15 +40,15 @@ impl<M> Algorithm for RecursiveLSTD<M> {
 
 impl<S, A, M: Projector<S>> OnlineLearner<S, A> for RecursiveLSTD<M> {
     fn handle_transition(&mut self, t: &Transition<S, A>) {
-        let phi_s = self.fa_theta.borrow().projector.project(t.from.state());
-        let v = self.fa_theta.borrow().evaluate_phi(&phi_s);
+        let phi_s = self.fa_theta.projector.project(t.from.state());
+        let v = self.fa_theta.evaluate_phi(&phi_s);
         let phi_s = self.expand_phi(phi_s);
 
         let (pd, residual) = if t.terminated() {
             (phi_s.clone(), t.reward - v)
         } else {
-            let phi_ns = self.fa_theta.borrow().projector.project(t.to.state());
-            let nv = self.fa_theta.borrow().evaluate_phi(&phi_ns);
+            let phi_ns = self.fa_theta.projector.project(t.to.state());
+            let nv = self.fa_theta.evaluate_phi(&phi_ns);
             let phi_ns = self.expand_phi(phi_ns);
 
             (
@@ -82,7 +82,7 @@ where
     ScalarLFA<M>: VFunction<S>,
 {
     fn predict_v(&mut self, s: &S) -> f64 {
-        self.fa_theta.borrow().evaluate(s).unwrap()
+        self.fa_theta.evaluate(s).unwrap()
     }
 }
 
@@ -96,6 +96,6 @@ where
     ScalarLFA<M>: Parameterised,
 {
     fn weights(&self) -> Matrix<f64> {
-        self.fa_theta.borrow().weights()
+        self.fa_theta.weights()
     }
 }

--- a/src/prediction/mc/gradient_mc.rs
+++ b/src/prediction/mc/gradient_mc.rs
@@ -39,7 +39,7 @@ impl<S, A, V: VFunction<S>> BatchLearner<S, A> for GradientMC<V> {
             sum = t.reward + self.gamma * sum;
 
             let s = t.from.state();
-            let v_est = self.v_func.borrow().evaluate(s).unwrap();
+            let v_est = self.v_func.evaluate(s).unwrap();
             let _ = self.v_func.borrow_mut().update(s, self.alpha * (sum - v_est));
         })
     }
@@ -47,7 +47,7 @@ impl<S, A, V: VFunction<S>> BatchLearner<S, A> for GradientMC<V> {
 
 impl<S, V: VFunction<S>> ValuePredictor<S> for GradientMC<V> {
     fn predict_v(&mut self, s: &S) -> f64 {
-        self.v_func.borrow().evaluate(s).unwrap()
+        self.v_func.evaluate(s).unwrap()
     }
 }
 
@@ -55,6 +55,6 @@ impl<S, A, V: VFunction<S>> ActionValuePredictor<S, A> for GradientMC<V> {}
 
 impl<V: Parameterised> Parameterised for GradientMC<V> {
     fn weights(&self) -> Matrix<f64> {
-        self.v_func.borrow().weights()
+        self.v_func.weights()
     }
 }

--- a/src/prediction/td/td.rs
+++ b/src/prediction/td/td.rs
@@ -48,13 +48,13 @@ impl<S, A, V: VFunction<S>> OnlineLearner<S, A> for TD<V> {
 }
 
 impl<S, V: VFunction<S>> ValuePredictor<S> for TD<V> {
-    fn predict_v(&mut self, s: &S) -> f64 { self.v_func.borrow().evaluate(s).unwrap() }
+    fn predict_v(&mut self, s: &S) -> f64 { self.v_func.evaluate(s).unwrap() }
 }
 
 impl<S, A, V: VFunction<S>> ActionValuePredictor<S, A> for TD<V> {}
 
 impl<V: Parameterised> Parameterised for TD<V> {
     fn weights(&self) -> Matrix<f64> {
-        self.v_func.borrow().weights()
+        self.v_func.weights()
     }
 }

--- a/src/prediction/td/td_lambda.rs
+++ b/src/prediction/td/td_lambda.rs
@@ -43,13 +43,13 @@ impl<M> Algorithm for TDLambda<M> {
 
 impl<S, A, M: Projector<S>> OnlineLearner<S, A> for TDLambda<M> {
     fn handle_transition(&mut self, t: &Transition<S, A>) {
-        let phi_s = self.fa_theta.borrow().projector.project(t.from.state());
-        let v = self.fa_theta.borrow().evaluate_phi(&phi_s);
+        let phi_s = self.fa_theta.projector.project(t.from.state());
+        let v = self.fa_theta.evaluate_phi(&phi_s);
 
         let decay_rate = self.trace.lambda.value() * self.gamma.value();
 
         self.trace.decay(decay_rate);
-        self.trace.update(&phi_s.expanded(self.fa_theta.borrow().projector.dim()));
+        self.trace.update(&phi_s.expanded(self.fa_theta.projector.dim()));
 
         let z = self.trace.get();
         let td_error = if t.terminated() {
@@ -69,7 +69,7 @@ where
     ScalarLFA<M>: VFunction<S>,
 {
     fn predict_v(&mut self, s: &S) -> f64 {
-        self.fa_theta.borrow().evaluate(s).unwrap()
+        self.fa_theta.evaluate(s).unwrap()
     }
 }
 
@@ -83,6 +83,6 @@ where
     ScalarLFA<M>: Parameterised
 {
     fn weights(&self) -> Matrix<f64> {
-        self.fa_theta.borrow().weights()
+        self.fa_theta.weights()
     }
 }


### PR DESCRIPTION
Before we were using a type alias to Rc<RefCell<T>>. Now we use a newtype to wrap around the Rc<RefCell<T>> type and implement the borrow... methods on top. This allows us to implement Deref on top which, while unsafe, adds a more ergonomic way of calling non-mutable methods on the interior object. This is based on the gist available [here](https://gist.github.com/stevedonovan/7e3a6d8c8921e3eff16c4b11ab82b8d7).