### PR TITLE
Add rendering, fix bugs in Acrobot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ slog = "2.4"
 slog-term = "2.4"
 slog-async = "2.3"
 
+ggez = "0.4.4"
+
 [dev-dependencies]
 serde_test = "1.0"
 

--- a/src/domains/acrobot.rs
+++ b/src/domains/acrobot.rs
@@ -89,7 +89,7 @@ impl Acrobot {
         ns[StateIndex::DTHETA2] =
             clip!(LIMITS_DTHETA2.0, ns[StateIndex::DTHETA2], LIMITS_DTHETA2.1);
 
-        self.state = ns;
+        self.state = ns.slice(s!(0..4)).to_owned();
     }
 
     fn grad(state: &Vector) -> Vector {
@@ -114,7 +114,7 @@ impl Acrobot {
             / (M2 * LC2 * LC2 + I2 - d2 * d2 / d1);
         let ddtheta1 = -(d2 * ddtheta2 + phi1) / d1;
 
-        Vector::from_vec(vec![dtheta1, dtheta2, ddtheta1, ddtheta2])
+        Vector::from_vec(vec![dtheta1, dtheta2, ddtheta1, ddtheta2, 0.0])
     }
 }
 

--- a/src/domains/cart_pole.rs
+++ b/src/domains/cart_pole.rs
@@ -59,8 +59,8 @@ impl CartPole {
     }
 
     fn update_state(&mut self, a: usize) {
-        let fx = |_x, y| CartPole::grad(ALL_ACTIONS[a], &y);
-        let mut ns = runge_kutta4(&fx, 0.0, self.state.clone(), TAU);
+        let fx = |y: &Vector| CartPole::grad(ALL_ACTIONS[a], y);
+        let mut ns = runge_kutta4(&fx, self.state.clone(), array![0.0, TAU]);
 
         ns[StateIndex::X] = clip!(LIMITS_X.0, ns[StateIndex::X], LIMITS_X.1);
         ns[StateIndex::DX] = clip!(LIMITS_DX.0, ns[StateIndex::DX], LIMITS_DX.1);

--- a/src/domains/hiv.rs
+++ b/src/domains/hiv.rs
@@ -86,9 +86,9 @@ impl HIVTreatment {
 
         self.eps = eps;
 
-        let mut ns = runge_kutta4(&fx, self.state.clone(), array![DT_STEP]);
+        let mut ns = runge_kutta4(&fx, self.state.clone(), array![0.0, DT_STEP]);
         for _ in 1..SIM_STEPS {
-            ns = runge_kutta4(&fx, ns, array![DT_STEP]);
+            ns = runge_kutta4(&fx, ns, array![0.0, DT_STEP]);
         }
 
         self.state = ns;

--- a/src/domains/hiv.rs
+++ b/src/domains/hiv.rs
@@ -82,13 +82,13 @@ impl HIVTreatment {
 
     fn update_state(&mut self, a: usize) {
         let eps = ALL_ACTIONS[a];
-        let fx = |_x, y| HIVTreatment::grad(eps, &y);
+        let fx = |y: &Vector| HIVTreatment::grad(eps, y);
 
         self.eps = eps;
 
-        let mut ns = runge_kutta4(&fx, 0.0, self.state.clone(), DT_STEP);
+        let mut ns = runge_kutta4(&fx, self.state.clone(), array![DT_STEP]);
         for _ in 1..SIM_STEPS {
-            ns = runge_kutta4(&fx, 0.0, ns, DT_STEP);
+            ns = runge_kutta4(&fx, ns, array![DT_STEP]);
         }
 
         self.state = ns;

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -154,6 +154,9 @@ pub trait Domain {
 
     /// Returns an instance of the action space type class.
     fn action_space(&self) -> Self::ActionSpace;
+
+    /// Render environment
+    fn render(&self, _ctx: &mut ggez::Context) {}
 }
 
 mod ode;
@@ -163,7 +166,7 @@ mod grid_world;
 
 import_all!(mountain_car);
 import_all!(cart_pole);
-import_all!(acrobat);
+import_all!(acrobot);
 import_all!(hiv);
 import_all!(cliff_walk);
 

--- a/src/domains/ode.rs
+++ b/src/domains/ode.rs
@@ -1,10 +1,22 @@
 use crate::core::Vector;
+use ndarray::{Axis, Array2};
 
-pub(crate) fn runge_kutta4(fx: &Fn(f64, Vector) -> Vector, x: f64, y: Vector, dx: f64) -> Vector {
-    let k1 = dx * fx(x, y.clone());
-    let k2 = dx * fx(x + dx / 2.0, y.clone() + k1.clone() / 2.0);
-    let k3 = dx * fx(x + dx / 2.0, y.clone() + k2.clone() / 2.0);
-    let k4 = dx * fx(x + dx, y.clone() + k3.clone());
+pub(crate) fn runge_kutta4(fx: &Fn(&Vector) -> Vector, y: Vector, times: Vector) -> Vector {
+    // more or less copied from python version
+    let mut yout = Array2::zeros((times.len(), y.len()));
+    yout.row_mut(0).assign(&y);
+    for i in 0..(times.len()-1) {
+        // let t = times[i];
+        let dt = times[i+1] - times[i];
+        let dt2 = dt / 2.0;
+        let y0 = yout.row(i).to_owned();
 
-    y + (k1 + 2.0 * k2 + 2.0 * k3 + k4) / 6.0
+        let k1 = fx(&y0);
+        let k2 = fx(&(y0.clone() + dt2*k1.clone()));
+        let k3 = fx(&(y0.clone() + dt2 * k2.clone()));
+        let k4 = fx(&(y0.clone() + dt * k3.clone()));
+
+        yout.row_mut(i+1).assign(&(y0 + dt / 6.0 * (k1 + 2.0 * k2 + 2.0 * k3 + k4)));
+    }
+    yout.row(yout.len_of(Axis(0))-1).to_owned()
 }


### PR DESCRIPTION
I have used this crate's Acrobot in my work lately. I noticed after a while that something was wrong: When I exported the states visited by my agent, it looked unnatural and maybe bugged. So I implemented rendering using `ggez`. Why `ggez`: because it is the only crate I found where you can create shapes as easily as in Python. Then I carefully made sure that everything in our Acrobot should be equivalent to what happens in the Python implementation (fixed a typo and reimplemented runge_kutta4). I found the result satisfactory - I tested it by playing with Acrobot myself using [this code](https://github.com/Ploppz/play-acrobot). Just `cargo run` and use left and right arrows.
I think it is crucial to visualize or verify the dynamics of environments/domains we implement. What other domains have not been tested?

* Fix a typo in `Acrobot::grad`
* Add optional `render()` to `Domain`
* Rewrite `runge_kutta4` to be equivalent to the one used in the Python implementation of Acrobot.
* Change name `Acrobat` -> `Acrobot`

Important: I had to propagate the changes I did in `runge_kutta4`, to the domains `hiv` and `cart_pole`. I have not verified that the changes in these environments are correct yet, so this needs review.

I would add the code that lets you play Acrobot yourself as an example or a bin maybe, but I can still not do any of `cargo run --example .. `, `cargo run --bin ..` or `cargo test` because of #54.
