### PR TITLE
Abstract over Shared types

### DIFF
--- a/examples/greedy_gq.rs
+++ b/examples/greedy_gq.rs
@@ -6,7 +6,7 @@ use rsrl::{
     control::gtd::GreedyGQ,
     core::{make_shared, run, Evaluation, Parameter, SerialExperiment},
     domains::{Domain, MountainCar},
-    fa::{basis::fixed::Fourier, LFA},
+    fa::{basis::{Composable, fixed::Fourier}, LFA},
     geometry::Space,
     logging,
     policies::fixed::{EpsilonGreedy, Greedy, Random},
@@ -20,18 +20,18 @@ fn main() {
         let n_actions = domain.action_space().card().into();
 
         // Build the linear value functions using a fourier basis projection.
-        let bases = Fourier::from_space(3, domain.state_space());
-        let v_func = make_shared(LFA::scalar(bases.clone()));
+        let bases = Fourier::from_space(3, domain.state_space()).with_constant();
+        let v_func = LFA::scalar(bases.clone());
         let q_func = make_shared(LFA::vector(bases, n_actions));
 
         // Build a stochastic behaviour policy with exponential epsilon.
-        let policy = make_shared(EpsilonGreedy::new(
+        let policy = EpsilonGreedy::new(
             Greedy::new(q_func.clone()),
             Random::new(n_actions),
-            Parameter::exponential(0.3, 0.001, 0.99),
-        ));
+            Parameter::exponential(0.2, 0.0001, 0.99),
+        );
 
-        GreedyGQ::new(q_func, v_func, policy, 1e-3, 1e-4, 0.99)
+        GreedyGQ::new(q_func, v_func, policy, 0.01, 0.001, 0.99)
     };
 
     let domain_builder = Box::new(MountainCar::default);

--- a/examples/pal.rs
+++ b/examples/pal.rs
@@ -6,7 +6,7 @@ use rsrl::{
     control::td::PAL,
     core::{make_shared, run, Evaluation, Parameter, SerialExperiment},
     domains::{Domain, MountainCar},
-    fa::{basis::fixed::Fourier, LFA},
+    fa::{basis::{Composable, fixed::Fourier}, LFA},
     geometry::Space,
     logging,
     policies::fixed::{EpsilonGreedy, Greedy, Random},
@@ -17,19 +17,16 @@ fn main() {
     let mut agent = {
         let n_actions = domain.action_space().card().into();
 
-        // Build the linear value function using a fourier basis projection and the
-        // appropriate eligibility trace.
-        let bases = Fourier::from_space(3, domain.state_space());
+        let bases = Fourier::from_space(3, domain.state_space()).with_constant();
         let q_func = make_shared(LFA::vector(bases, n_actions));
 
-        // Build a stochastic behaviour policy with exponential epsilon.
-        let policy = make_shared(EpsilonGreedy::new(
+        let policy = EpsilonGreedy::new(
             Greedy::new(q_func.clone()),
             Random::new(n_actions),
-            Parameter::exponential(0.7, 0.01, 0.9),
-        ));
+            Parameter::exponential(0.5, 0.001, 0.99),
+        );
 
-        PAL::new(q_func, policy, 0.01, 0.99)
+        PAL::new(q_func, policy, 0.001, 1.0)
     };
 
     let logger = logging::root(logging::stdout());

--- a/examples/sarsa_lambda.rs
+++ b/examples/sarsa_lambda.rs
@@ -6,7 +6,7 @@ use rsrl::{
     control::td::SARSALambda,
     core::{make_shared, run, Evaluation, Parameter, SerialExperiment, Trace},
     domains::{Domain, MountainCar},
-    fa::{basis::fixed::Fourier, LFA},
+    fa::{basis::{Composable, fixed::Fourier}, LFA},
     geometry::Space,
     logging,
     policies::fixed::{EpsilonGreedy, Greedy, Random},
@@ -17,20 +17,17 @@ fn main() {
     let mut agent = {
         let n_actions = domain.action_space().card().into();
 
-        // Build the linear value function using a fourier basis projection and the
-        // appropriate eligibility trace.
-        let bases = Fourier::from_space(3, domain.state_space());
-        let trace = Trace::replacing(0.5, bases.dim());
+        let bases = Fourier::from_space(3, domain.state_space()).with_constant();
+        let trace = Trace::replacing(0.3, bases.dim());
         let q_func = make_shared(LFA::vector(bases, n_actions));
 
-        // Build a stochastic behaviour policy with exponential epsilon.
-        let policy = make_shared(EpsilonGreedy::new(
+        let policy = EpsilonGreedy::new(
             Greedy::new(q_func.clone()),
             Random::new(n_actions),
-            Parameter::exponential(0.7, 0.001, 0.99),
-        ));
+            Parameter::exponential(0.3, 0.001, 0.99),
+        );
 
-        SARSALambda::new(q_func, policy, trace, 0.005, 1.0)
+        SARSALambda::new(q_func, policy, trace, 0.001, 0.99)
     };
 
     let logger = logging::root(logging::stdout());

--- a/src/control/actor_critic/nac.rs
+++ b/src/control/actor_critic/nac.rs
@@ -7,14 +7,14 @@ use std::marker::PhantomData;
 
 /// Natural actor-critic.
 pub struct NAC<C, P> {
-    pub critic: Shared<C>,
-    pub policy: Shared<P>,
+    pub critic: C,
+    pub policy: P,
 
     pub alpha: Parameter,
 }
 
 impl<C, P> NAC<C, P> {
-    pub fn new<T: Into<Parameter>>(critic: Shared<C>, policy: Shared<P>, alpha: T) -> Self {
+    pub fn new<T: Into<Parameter>>(critic: C, policy: P, alpha: T) -> Self {
         NAC {
             critic,
             policy,
@@ -32,8 +32,8 @@ where
     fn handle_terminal(&mut self) {
         self.alpha = self.alpha.step();
 
-        self.critic.borrow_mut().handle_terminal();
-        self.policy.borrow_mut().handle_terminal();
+        self.critic.handle_terminal();
+        self.policy.handle_terminal();
     }
 }
 
@@ -43,15 +43,15 @@ where
     P: ParameterisedPolicy<S>,
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
-        self.critic.borrow_mut().handle_transition(t);
-        self.policy.borrow_mut().update_raw(
+        self.critic.handle_transition(t);
+        self.policy.update_raw(
             self.alpha.value() * self.critic.weights()
         );
     }
 
     fn handle_sequence(&mut self, seq: &[Transition<S, P::Action>]) {
-        self.critic.borrow_mut().handle_sequence(seq);
-        self.policy.borrow_mut().update_raw(
+        self.critic.handle_sequence(seq);
+        self.policy.update_raw(
             self.alpha.value() * self.critic.weights()
         );
     }
@@ -62,7 +62,7 @@ where
     C: ValuePredictor<S>,
 {
     fn predict_v(&mut self, s: &S) -> f64 {
-        self.critic.borrow_mut().predict_v(s)
+        self.critic.predict_v(s)
     }
 }
 
@@ -72,11 +72,11 @@ where
     P: Policy<S>,
 {
     fn predict_qs(&mut self, s: &S) -> Vector<f64> {
-        self.critic.borrow_mut().predict_qs(s)
+        self.critic.predict_qs(s)
     }
 
     fn predict_qsa(&mut self, s: &S, a: P::Action) -> f64 {
-        self.critic.borrow_mut().predict_qsa(s, a)
+        self.critic.predict_qsa(s, a)
     }
 }
 
@@ -85,10 +85,10 @@ where
     P: Policy<S>,
 {
     fn sample_target(&mut self, s: &S) -> P::Action {
-        self.policy.borrow_mut().sample(s)
+        self.policy.sample(s)
     }
 
     fn sample_behaviour(&mut self, s: &S) -> P::Action {
-        self.policy.borrow_mut().sample(s)
+        self.policy.sample(s)
     }
 }

--- a/src/control/actor_critic/qac.rs
+++ b/src/control/actor_critic/qac.rs
@@ -5,14 +5,14 @@ use std::marker::PhantomData;
 
 /// Action-value actor-critic.
 pub struct QAC<C, P> {
-    pub critic: Shared<C>,
-    pub policy: Shared<P>,
+    pub critic: C,
+    pub policy: P,
 
     pub alpha: Parameter,
 }
 
 impl<C, P> QAC<C, P> {
-    pub fn new<T: Into<Parameter>>(critic: Shared<C>, policy: Shared<P>, alpha: T) -> Self {
+    pub fn new<T: Into<Parameter>>(critic: C, policy: P, alpha: T) -> Self {
         QAC {
             critic,
             policy,
@@ -30,8 +30,8 @@ where
     fn handle_terminal(&mut self) {
         self.alpha = self.alpha.step();
 
-        self.critic.borrow_mut().handle_terminal();
-        self.policy.borrow_mut().handle_terminal();
+        self.critic.handle_terminal();
+        self.policy.handle_terminal();
     }
 }
 
@@ -42,22 +42,22 @@ where
     P::Action: Clone,
 {
     fn handle_transition(&mut self, t: &Transition<S, P::Action>) {
-        self.critic.borrow_mut().handle_transition(t);
+        self.critic.handle_transition(t);
 
         let s = t.from.state();
-        let qsa = self.critic.borrow_mut().predict_qsa(s, t.action.clone());
+        let qsa = self.critic.predict_qsa(s, t.action.clone());
 
-        self.policy.borrow_mut().update(s, t.action.clone(), self.alpha * qsa);
+        self.policy.update(s, t.action.clone(), self.alpha * qsa);
     }
 
     fn handle_sequence(&mut self, seq: &[Transition<S, P::Action>]) {
-        self.critic.borrow_mut().handle_sequence(seq);
+        self.critic.handle_sequence(seq);
 
         for t in seq {
             let s = t.from.state();
-            let qsa = self.critic.borrow_mut().predict_qsa(s, t.action.clone());
+            let qsa = self.critic.predict_qsa(s, t.action.clone());
 
-            self.policy.borrow_mut().update(s, t.action.clone(), self.alpha * qsa);
+            self.policy.update(s, t.action.clone(), self.alpha * qsa);
         }
     }
 }
@@ -67,7 +67,7 @@ where
     C: ValuePredictor<S>,
 {
     fn predict_v(&mut self, s: &S) -> f64 {
-        self.critic.borrow_mut().predict_v(s)
+        self.critic.predict_v(s)
     }
 }
 
@@ -77,11 +77,11 @@ where
     P: Policy<S>,
 {
     fn predict_qs(&mut self, s: &S) -> Vector<f64> {
-        self.critic.borrow_mut().predict_qs(s)
+        self.critic.predict_qs(s)
     }
 
     fn predict_qsa(&mut self, s: &S, a: P::Action) -> f64 {
-        self.critic.borrow_mut().predict_qsa(s, a)
+        self.critic.predict_qsa(s, a)
     }
 }
 
@@ -90,10 +90,10 @@ where
     P: ParameterisedPolicy<S>,
 {
     fn sample_target(&mut self, s: &S) -> P::Action {
-        self.policy.borrow_mut().sample(s)
+        self.policy.sample(s)
     }
 
     fn sample_behaviour(&mut self, s: &S) -> P::Action {
-        self.policy.borrow_mut().sample(s)
+        self.policy.sample(s)
     }
 }

--- a/src/control/mc/reinforce.rs
+++ b/src/control/mc/reinforce.rs
@@ -6,14 +6,14 @@ use crate::policies::{Policy, ParameterisedPolicy};
 use std::marker::PhantomData;
 
 pub struct REINFORCE<P> {
-    pub policy: Shared<P>,
+    pub policy: P,
 
     pub alpha: Parameter,
     pub gamma: Parameter,
 }
 
 impl<P> REINFORCE<P> {
-    pub fn new<T1, T2>(policy: Shared<P>, alpha: T1, gamma: T2) -> Self
+    pub fn new<T1, T2>(policy: P, alpha: T1, gamma: T2) -> Self
     where
         T1: Into<Parameter>,
         T2: Into<Parameter>,
@@ -32,7 +32,7 @@ impl<P: Algorithm> Algorithm for REINFORCE<P> {
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
 
-        self.policy.borrow_mut().handle_terminal();
+        self.policy.handle_terminal();
     }
 }
 
@@ -48,7 +48,7 @@ where
         for t in batch.into_iter().rev() {
             ret = t.reward + self.gamma * ret;
 
-            self.policy.borrow_mut().update(
+            self.policy.update(
                 t.from.state(),
                 t.action.clone(),
                 self.alpha * ret / z
@@ -58,9 +58,9 @@ where
 }
 
 impl<S, P: ParameterisedPolicy<S>> Controller<S, P::Action> for REINFORCE<P> {
-    fn sample_target(&mut self, s: &S) -> P::Action { self.policy.borrow_mut().sample(s) }
+    fn sample_target(&mut self, s: &S) -> P::Action { self.policy.sample(s) }
 
-    fn sample_behaviour(&mut self, s: &S) -> P::Action { self.policy.borrow_mut().sample(s) }
+    fn sample_behaviour(&mut self, s: &S) -> P::Action { self.policy.sample(s) }
 }
 
 impl<P: Parameterised> Parameterised for REINFORCE<P> {
@@ -73,6 +73,6 @@ impl<P: Parameterised> Parameterised for REINFORCE<P> {
     }
 
     fn weights_view_mut(&mut self) -> MatrixViewMut<f64> {
-        unimplemented!()
+        self.policy.weights_view_mut()
     }
 }

--- a/src/control/td/sarsa.rs
+++ b/src/control/td/sarsa.rs
@@ -13,15 +13,15 @@ use std::marker::PhantomData;
 /// - Singh, S. P., Sutton, R. S. (1996). Reinforcement learning with replacing
 /// eligibility traces. Machine Learning 22:123–158.
 pub struct SARSA<Q, P> {
-    pub q_func: Shared<Q>,
-    pub policy: Shared<P>,
+    pub q_func: Q,
+    pub policy: P,
 
     pub alpha: Parameter,
     pub gamma: Parameter,
 }
 
 impl<Q, P> SARSA<Q, P> {
-    pub fn new<T1, T2>(q_func: Shared<Q>, policy: Shared<P>, alpha: T1, gamma: T2) -> Self
+    pub fn new<T1, T2>(q_func: Q, policy: P, alpha: T1, gamma: T2) -> Self
     where
         T1: Into<Parameter>,
         T2: Into<Parameter>,
@@ -41,7 +41,7 @@ impl<Q, P: Algorithm> Algorithm for SARSA<Q, P> {
         self.alpha = self.alpha.step();
         self.gamma = self.gamma.step();
 
-        self.policy.borrow_mut().handle_terminal();
+        self.policy.handle_terminal();
     }
 }
 
@@ -57,13 +57,13 @@ where
             t.reward - qsa
         } else {
             let ns = t.to.state();
-            let na = self.policy.borrow_mut().sample(ns);
+            let na = self.policy.sample(ns);
             let nqsna = self.q_func.evaluate_index(&self.q_func.to_features(ns), na).unwrap();
 
             t.reward + self.gamma * nqsna - qsa
         };
 
-        self.q_func.borrow_mut().update_index(
+        self.q_func.update_index(
             &self.q_func.to_features(s),
             t.action, self.alpha * residual
         ).ok();
@@ -72,11 +72,11 @@ where
 
 impl<S, Q, P: Policy<S>> Controller<S, P::Action> for SARSA<Q, P> {
     fn sample_target(&mut self, s: &S) -> P::Action {
-        self.policy.borrow_mut().sample(s)
+        self.policy.sample(s)
     }
 
     fn sample_behaviour(&mut self, s: &S) -> P::Action {
-        self.policy.borrow_mut().sample(s)
+        self.policy.sample(s)
     }
 }
 
@@ -86,7 +86,7 @@ where
     P: FinitePolicy<S>,
 {
     fn predict_v(&mut self, s: &S) -> f64 {
-        self.predict_qs(s).dot(&self.policy.borrow_mut().probabilities(s))
+        self.predict_qs(s).dot(&self.policy.probabilities(s))
     }
 }
 
@@ -114,6 +114,6 @@ impl<Q: Parameterised, P> Parameterised for SARSA<Q, P> {
     }
 
     fn weights_view_mut(&mut self) -> MatrixViewMut<f64> {
-        unimplemented!()
+        self.q_func.weights_view_mut()
     }
 }

--- a/src/core/algorithms.rs
+++ b/src/core/algorithms.rs
@@ -1,4 +1,5 @@
 #![allow(unused_variables)]
+use crate::core::Shared;
 use crate::domains::{Transition, Observation::Terminal};
 use crate::geometry::Vector;
 
@@ -44,5 +45,54 @@ pub trait ActionValuePredictor<S, A>: ValuePredictor<S> {
     /// Compute the estimated value of Q(s, ·).
     fn predict_qs(&mut self, s: &S) -> Vector<f64> {
         unimplemented!()
+    }
+}
+
+// Shared<T> impls:
+impl<T: Algorithm> Algorithm for Shared<T> {
+    fn handle_terminal(&mut self) {
+        self.borrow_mut().handle_terminal()
+    }
+}
+
+impl<S, A, T: OnlineLearner<S, A>> OnlineLearner<S, A> for Shared<T> {
+    fn handle_transition(&mut self, transition: &Transition<S, A>) {
+        self.borrow_mut().handle_transition(transition)
+    }
+
+    fn handle_sequence(&mut self, sequence: &[Transition<S, A>]) {
+        self.borrow_mut().handle_sequence(sequence)
+    }
+}
+
+impl<S, A, T: BatchLearner<S, A>> BatchLearner<S, A> for Shared<T> {
+    fn handle_batch(&mut self, batch: &[Transition<S, A>]) {
+        self.borrow_mut().handle_batch(batch)
+    }
+}
+
+impl<S, A, T: Controller<S, A>> Controller<S, A> for Shared<T> {
+    fn sample_target(&mut self, s: &S) -> A {
+        self.borrow_mut().sample_target(s)
+    }
+
+    fn sample_behaviour(&mut self, s: &S) -> A {
+        self.borrow_mut().sample_behaviour(s)
+    }
+}
+
+impl<S, T: ValuePredictor<S>> ValuePredictor<S> for Shared<T> {
+    fn predict_v(&mut self, s: &S) -> f64 {
+        self.borrow_mut().predict_v(s)
+    }
+}
+
+impl<S, A, T: ActionValuePredictor<S, A>> ActionValuePredictor<S, A> for Shared<T> {
+    fn predict_qsa(&mut self, s: &S, a: A) -> f64 {
+        self.borrow_mut().predict_qsa(s, a)
+    }
+
+    fn predict_qs(&mut self, s: &S) -> Vector<f64> {
+        self.borrow_mut().predict_qs(s)
     }
 }

--- a/src/core/memory.rs
+++ b/src/core/memory.rs
@@ -5,6 +5,8 @@ use std::{
     rc::Rc,
 };
 
+pub fn make_shared<T>(t: T) -> Shared<T> { Shared(Rc::new(RefCell::new(t))) }
+
 pub struct Shared<T>(Rc<RefCell<T>>);
 
 impl<T> Shared<T> {
@@ -51,5 +53,3 @@ impl<T> Clone for Shared<T> {
         Shared(self.0.clone())
     }
 }
-
-pub fn make_shared<T>(t: T) -> Shared<T> { Shared(Rc::new(RefCell::new(t))) }

--- a/src/fa/mod.rs
+++ b/src/fa/mod.rs
@@ -1,5 +1,8 @@
 //! Function approximation and value function representation module.
-use crate::{core::Shared, geometry::Vector};
+use crate::{
+    core::Shared,
+    geometry::{Vector, Matrix, MatrixView, MatrixViewMut},
+};
 
 extern crate lfa;
 pub use self::lfa::{basis, core::*, eval, transforms, TransformedLFA, LFA};
@@ -19,3 +22,44 @@ impl<S: ?Sized, T: Embedded<S> + ScalarApproximator<Output = f64>> VFunction<S> 
 pub trait QFunction<S: ?Sized>: Embedded<S> + VectorApproximator {}
 
 impl<S: ?Sized, T: Embedded<S> + VectorApproximator> QFunction<S> for T {}
+
+// Shared<T> impls:
+impl<S: ?Sized, T: Embedded<S>> Embedded<S> for Shared<T> {
+    fn n_features(&self) -> usize {
+        self.borrow().n_features()
+    }
+
+    fn to_features(&self, s: &S) -> Features {
+        self.borrow().to_features(s)
+    }
+}
+
+impl<T: Approximator> Approximator for Shared<T> {
+    type Output = T::Output;
+
+    fn n_outputs(&self) -> usize { self.borrow().n_outputs() }
+
+    fn evaluate(&self, features: &Features) -> EvaluationResult<Self::Output> {
+        self.borrow().evaluate(features)
+    }
+
+    fn update(&mut self, features: &Features, update: Self::Output) -> UpdateResult<()> {
+        self.borrow_mut().update(features, update)
+    }
+}
+
+impl<T: Parameterised> Parameterised for Shared<T> {
+    fn weights(&self) -> Matrix<f64> { self.borrow().weights() }
+
+    fn weights_view(&self) -> MatrixView<f64> {
+        unsafe { self.as_ptr().as_ref().unwrap().weights_view() }
+    }
+
+    fn weights_view_mut(&mut self) -> MatrixViewMut<f64> {
+        unsafe { self.as_ptr().as_mut().unwrap().weights_view_mut() }
+    }
+
+    fn weights_dim(&self) -> (usize, usize) { self.borrow().weights_dim() }
+
+    fn weights_count(&self) -> usize { self.borrow().weights_count() }
+}

--- a/src/policies/fixed/boltzmann.rs
+++ b/src/policies/fixed/boltzmann.rs
@@ -9,14 +9,14 @@ use rand::{rngs::ThreadRng, thread_rng};
 use std::f64;
 
 pub struct Boltzmann<Q> {
-    q_func: Shared<Q>,
+    q_func: Q,
 
     tau: Parameter,
     rng: ThreadRng,
 }
 
 impl<Q> Boltzmann<Q> {
-    pub fn new<T: Into<Parameter>>(q_func: Shared<Q>, tau: T) -> Self {
+    pub fn new<T: Into<Parameter>>(q_func: Q, tau: T) -> Self {
         Boltzmann {
             q_func,
 

--- a/src/policies/fixed/epsilon_greedy.rs
+++ b/src/policies/fixed/epsilon_greedy.rs
@@ -22,7 +22,7 @@ impl<Q> EpsilonGreedy<Q> {
     }
 
     #[allow(non_snake_case)]
-    pub fn from_Q<S, T: Into<Parameter>>(q_func: Shared<Q>, epsilon: T) -> Self
+    pub fn from_Q<S, T: Into<Parameter>>(q_func: Q, epsilon: T) -> Self
     where Q: QFunction<S> {
         let greedy = Greedy::new(q_func);
         let random = Random::new(greedy.n_actions());

--- a/src/policies/fixed/greedy.rs
+++ b/src/policies/fixed/greedy.rs
@@ -6,10 +6,10 @@ use crate::{
 };
 use rand::thread_rng;
 
-pub struct Greedy<Q>(Shared<Q>);
+pub struct Greedy<Q>(Q);
 
 impl<Q> Greedy<Q> {
-    pub fn new(q_func: Shared<Q>) -> Self { Greedy(q_func) }
+    pub fn new(q_func: Q) -> Self { Greedy(q_func) }
 }
 
 impl<Q> Algorithm for Greedy<Q> {}

--- a/src/policies/fixed/truncated_boltzmann.rs
+++ b/src/policies/fixed/truncated_boltzmann.rs
@@ -12,14 +12,14 @@ use std::f64;
 fn kappa(c: f64, x: f64) -> f64 { c / (1.0 + (-x).exp()) }
 
 pub struct TruncatedBoltzmann<Q> {
-    q_func: Shared<Q>,
+    q_func: Q,
 
     c: Parameter,
     rng: ThreadRng,
 }
 
 impl<Q> TruncatedBoltzmann<Q> {
-    pub fn new<T: Into<Parameter>>(q_func: Shared<Q>, c: T) -> Self {
+    pub fn new<T: Into<Parameter>>(q_func: Q, c: T) -> Self {
         TruncatedBoltzmann {
             q_func,
 

--- a/src/policies/mod.rs
+++ b/src/policies/mod.rs
@@ -83,3 +83,46 @@ pub mod fixed;
 pub mod parameterised;
 
 import_all!(perturbation);
+
+// Shared<T> impls:
+impl<S, T: Policy<S>> Policy<S> for Shared<T> {
+    type Action = T::Action;
+
+    fn sample(&mut self, input: &S) -> Self::Action {
+        self.borrow_mut().sample(input)
+    }
+
+    fn mpa(&mut self, s: &S) -> Self::Action {
+        self.borrow_mut().mpa(s)
+    }
+
+    fn probability(&mut self, input: &S, a: Self::Action) -> f64 {
+        self.borrow_mut().probability(input, a)
+    }
+}
+
+impl<S, T: FinitePolicy<S>> FinitePolicy<S> for Shared<T> {
+    fn n_actions(&self) -> usize {
+        self.borrow().n_actions()
+    }
+
+    fn probabilities(&mut self, input: &S) -> Vector<f64> {
+        self.borrow_mut().probabilities(input)
+    }
+}
+
+impl<S, T: DifferentiablePolicy<S>> DifferentiablePolicy<S> for Shared<T> {
+    fn grad_log(&self, input: &S, a: Self::Action) -> Matrix<f64> {
+        self.borrow().grad_log(input, a)
+    }
+}
+
+impl<S, T: ParameterisedPolicy<S>> ParameterisedPolicy<S> for Shared<T> {
+    fn update(&mut self, input: &S, a: Self::Action, error: f64) {
+        self.borrow_mut().update(input, a, error)
+    }
+
+    fn update_raw(&mut self, errors: Matrix<f64>) {
+        self.borrow_mut().update_raw(errors)
+    }
+}

--- a/src/policies/parameterised/dirac.rs
+++ b/src/policies/parameterised/dirac.rs
@@ -12,11 +12,11 @@ use ndarray::Axis;
 use std::ops::AddAssign;
 
 pub struct Dirac<F> {
-    pub fa: Shared<F>,
+    pub fa: F,
 }
 
 impl<F> Dirac<F> {
-    pub fn new(fa: Shared<F>) -> Self {
+    pub fn new(fa: F) -> Self {
         Dirac { fa, }
     }
 }
@@ -57,18 +57,16 @@ impl<F: Parameterised> Parameterised for Dirac<F> {
     }
 
     fn weights_view_mut(&mut self) -> MatrixViewMut<f64> {
-        unimplemented!()
+        self.fa.weights_view_mut()
     }
 }
 
 impl<S, F: VFunction<S> + Parameterised> ParameterisedPolicy<S> for Dirac<F> {
     fn update(&mut self, input: &S, _: f64, error: f64) {
-        self.fa.borrow_mut().update(&self.fa.to_features(input), error).ok();
+        self.fa.update(&self.fa.to_features(input), error).ok();
     }
 
     fn update_raw(&mut self, errors: Matrix<f64>) {
-        let mut fa = self.fa.borrow_mut();
-
-        fa.weights_view_mut().add_assign(&errors);
+        self.fa.weights_view_mut().add_assign(&errors);
     }
 }

--- a/src/policies/perturbation.rs
+++ b/src/policies/perturbation.rs
@@ -10,26 +10,26 @@ use rand::{
 use std::ops::Add;
 
 pub struct PerturbedPolicy<P, D, R = ThreadRng> {
-    pub base_policy: Shared<P>,
+    pub base_policy: P,
     pub noise_dist: D,
 
     rng: R,
 }
 
 impl<P, D> PerturbedPolicy<P, D> {
-    pub fn new(base_policy: Shared<P>, noise_dist: D) -> Self {
+    pub fn new(base_policy: P, noise_dist: D) -> Self {
         PerturbedPolicy::with_rng(base_policy, noise_dist, thread_rng())
     }
 }
 
 impl<P> PerturbedPolicy<P, Normal> {
-    pub fn normal(base_policy: Shared<P>, std_dev: f64) -> Self {
+    pub fn normal(base_policy: P, std_dev: f64) -> Self {
         PerturbedPolicy::with_rng(base_policy, Normal::new(0.0, std_dev), thread_rng())
     }
 }
 
 impl<P, D, R> PerturbedPolicy<P, D, R> {
-    pub fn with_rng(base_policy: Shared<P>, noise_dist: D, rng: R) -> Self {
+    pub fn with_rng(base_policy: P, noise_dist: D, rng: R) -> Self {
         PerturbedPolicy {
             base_policy,
             noise_dist,
@@ -40,7 +40,7 @@ impl<P, D, R> PerturbedPolicy<P, D, R> {
 
 impl<P: Algorithm, D, R> Algorithm for PerturbedPolicy<P, D, R> {
     fn handle_terminal(&mut self) {
-        self.base_policy.borrow_mut().handle_terminal();
+        self.base_policy.handle_terminal();
     }
 }
 
@@ -54,7 +54,7 @@ where
     type Action = P::Action;
 
     fn sample(&mut self, s: &S) -> P::Action {
-        let base_action = self.base_policy.borrow_mut().sample(s);
+        let base_action = self.base_policy.sample(s);
         let perturbation = self.noise_dist.sample(&mut self.rng);
 
         base_action + perturbation

--- a/src/prediction/gtd/gtd2.rs
+++ b/src/prediction/gtd/gtd2.rs
@@ -4,8 +4,8 @@ use crate::fa::{Approximator, Parameterised, Features, Projector, VFunction};
 use crate::geometry::{Space, MatrixView, MatrixViewMut};
 
 pub struct GTD2<F> {
-    pub fa_theta: Shared<F>,
-    pub fa_w: Shared<F>,
+    pub fa_theta: F,
+    pub fa_w: F,
 
     pub alpha: Parameter,
     pub beta: Parameter,
@@ -14,8 +14,8 @@ pub struct GTD2<F> {
 
 impl<F: Parameterised> GTD2<F> {
     pub fn new<T1, T2, T3>(
-        fa_theta: Shared<F>,
-        fa_w: Shared<F>,
+        fa_theta: F,
+        fa_w: F,
         alpha: T1,
         beta: T2,
         gamma: T3,
@@ -61,12 +61,12 @@ impl<S, A, F: VFunction<S>> OnlineLearner<S, A> for GTD2<F> {
             t.reward + self.gamma * self.fa_theta.evaluate(&phi_ns).unwrap() - v
         };
 
-        self.fa_w.borrow_mut().update(&phi_s, self.beta * (td_error - td_estimate)).unwrap();
+        self.fa_w.update(&phi_s, self.beta * (td_error - td_estimate)).unwrap();
 
         let dim = self.fa_theta.n_features();
         let pd = phi_s.expanded(dim) - self.gamma.value() * phi_ns.expanded(dim);
 
-        self.fa_theta.borrow_mut().update(&Features::Dense(pd), self.alpha * td_estimate).ok();
+        self.fa_theta.update(&Features::Dense(pd), self.alpha * td_estimate).ok();
     }
 }
 
@@ -88,6 +88,6 @@ impl<F: Parameterised> Parameterised for GTD2<F> {
     }
 
     fn weights_view_mut(&mut self) -> MatrixViewMut<f64> {
-        unimplemented!()
+        self.fa_theta.weights_view_mut()
     }
 }

--- a/src/prediction/gtd/tdc.rs
+++ b/src/prediction/gtd/tdc.rs
@@ -4,8 +4,8 @@ use crate::fa::{Approximator, Parameterised, Features, Projector, VFunction};
 use crate::geometry::{Space, MatrixView, MatrixViewMut};
 
 pub struct TDC<F> {
-    pub fa_theta: Shared<F>,
-    pub fa_w: Shared<F>,
+    pub fa_theta: F,
+    pub fa_w: F,
 
     pub alpha: Parameter,
     pub beta: Parameter,
@@ -14,8 +14,8 @@ pub struct TDC<F> {
 
 impl<F: Parameterised> TDC<F> {
     pub fn new<T1, T2, T3>(
-        fa_theta: Shared<F>,
-        fa_w: Shared<F>,
+        fa_theta: F,
+        fa_w: F,
         alpha: T1,
         beta: T2,
         gamma: T3,
@@ -61,14 +61,14 @@ impl<S, A, F: VFunction<S>> OnlineLearner<S, A> for TDC<F> {
             t.reward + self.gamma * self.fa_theta.evaluate(&phi_ns).unwrap() - v
         };
 
-        self.fa_w.borrow_mut().update(&phi_s, self.beta * (td_error - td_estimate)).ok();
+        self.fa_w.update(&phi_s, self.beta * (td_error - td_estimate)).ok();
 
         let dim = self.fa_theta.n_features();
         let phi =
             td_error * phi_s.expanded(dim) -
             td_estimate * self.gamma.value() * phi_ns.expanded(dim);
 
-        self.fa_theta.borrow_mut().update(&Features::Dense(phi), self.alpha.value()).ok();
+        self.fa_theta.update(&Features::Dense(phi), self.alpha.value()).ok();
     }
 }
 
@@ -90,6 +90,6 @@ impl<F: Parameterised> Parameterised for TDC<F> {
     }
 
     fn weights_view_mut(&mut self) -> MatrixViewMut<f64> {
-        unimplemented!()
+        self.fa_theta.weights_view_mut()
     }
 }

--- a/src/prediction/lstd/lambda_lspe.rs
+++ b/src/prediction/lstd/lambda_lspe.rs
@@ -10,7 +10,7 @@ use ndarray_linalg::solve::Solve;
 use std::ops::MulAssign;
 
 pub struct LambdaLSPE<F> {
-    pub fa_theta: Shared<F>,
+    pub fa_theta: F,
 
     pub alpha: Parameter,
     pub gamma: Parameter,
@@ -22,7 +22,7 @@ pub struct LambdaLSPE<F> {
 }
 
 impl<F: Parameterised> LambdaLSPE<F> {
-    pub fn new<T1, T2, T3>(fa_theta: Shared<F>, alpha: T1, gamma: T2, lambda: T3) -> Self
+    pub fn new<T1, T2, T3>(fa_theta: F, alpha: T1, gamma: T2, lambda: T3) -> Self
     where
         T1: Into<Parameter>,
         T2: Into<Parameter>,
@@ -50,11 +50,10 @@ impl<F: Parameterised> LambdaLSPE<F> {
         if let Ok(theta) = self.a.solve(&self.b).or_else(|_| {
             pinv(&self.a).map(|ainv| ainv.dot(&self.b))
         }) {
-            let mut fa = self.fa_theta.borrow_mut();
-            let mut weights = fa.weights_view_mut();
+            let mut w = self.fa_theta.weights_view_mut();
 
-            weights.mul_assign(1.0 - self.alpha);
-            weights.scaled_add(self.alpha.value(), &theta);
+            w.mul_assign(1.0 - self.alpha);
+            w.scaled_add(self.alpha.value(), &theta);
 
             self.a.fill(0.0);
             self.b.fill(0.0);
@@ -118,6 +117,6 @@ impl<F: Parameterised> Parameterised for LambdaLSPE<F> {
     }
 
     fn weights_view_mut(&mut self) -> MatrixViewMut<f64> {
-        unimplemented!()
+        self.fa_theta.weights_view_mut()
     }
 }

--- a/src/prediction/lstd/lstd.rs
+++ b/src/prediction/lstd/lstd.rs
@@ -9,7 +9,7 @@ use ndarray::Axis;
 use ndarray_linalg::solve::Solve;
 
 pub struct LSTD<F> {
-    pub fa_theta: Shared<F>,
+    pub fa_theta: F,
 
     pub gamma: Parameter,
 
@@ -18,7 +18,7 @@ pub struct LSTD<F> {
 }
 
 impl<F: Parameterised> LSTD<F> {
-    pub fn new<T: Into<Parameter>>(fa_theta: Shared<F>, gamma: T) -> Self {
+    pub fn new<T: Into<Parameter>>(fa_theta: F, gamma: T) -> Self {
         let dim = fa_theta.weights_dim();
 
         LSTD {
@@ -34,15 +34,14 @@ impl<F: Parameterised> LSTD<F> {
 
 impl<F: Parameterised> LSTD<F> {
     pub fn solve(&mut self) {
-        let mut fa = self.fa_theta.borrow_mut();
-        let mut weights = fa.weights_view_mut();
+        let mut w = self.fa_theta.weights_view_mut();
 
         if let Ok(theta) = self.a.solve(&self.b) {
             // First try the clean approach:
-            weights.assign(&theta);
+            w.assign(&theta);
         } else if let Ok(ainv) = pinv(&self.a) {
             // Otherwise solve via SVD:
-            weights.assign(&ainv.dot(&self.b));
+            w.assign(&ainv.dot(&self.b));
         }
     }
 }
@@ -95,6 +94,6 @@ impl<F: Parameterised> Parameterised for LSTD<F> {
     }
 
     fn weights_view_mut(&mut self) -> MatrixViewMut<f64> {
-        unimplemented!()
+        self.fa_theta.weights_view_mut()
     }
 }

--- a/src/prediction/lstd/recursive_lstd.rs
+++ b/src/prediction/lstd/recursive_lstd.rs
@@ -8,14 +8,14 @@ use crate::{
 use ndarray::Axis;
 
 pub struct RecursiveLSTD<F> {
-    pub fa_theta: Shared<F>,
+    pub fa_theta: F,
     pub gamma: Parameter,
 
     c_mat: Matrix<f64>,
 }
 
 impl<F: Parameterised> RecursiveLSTD<F> {
-    pub fn new<T: Into<Parameter>>(fa_theta: Shared<F>, gamma: T) -> Self {
+    pub fn new<T: Into<Parameter>>(fa_theta: F, gamma: T) -> Self {
         let n_features = fa_theta.weights_dim().0;
 
         RecursiveLSTD {
@@ -73,7 +73,7 @@ impl<S, A, F: VFunction<S>> OnlineLearner<S, A> for RecursiveLSTD<F> {
         let vg = v.dot(&g);
 
         self.c_mat.scaled_add(-1.0 / a, &vg);
-        self.fa_theta.borrow_mut().update(&Features::Dense(
+        self.fa_theta.update(&Features::Dense(
             v.index_axis_move(Axis(1), 0)
         ), residual / a).ok();
     }
@@ -97,6 +97,6 @@ impl<F: Parameterised> Parameterised for RecursiveLSTD<F> {
     }
 
     fn weights_view_mut(&mut self) -> MatrixViewMut<f64> {
-        unimplemented!()
+        self.fa_theta.weights_view_mut()
     }
 }

--- a/src/prediction/mc/gradient_mc.rs
+++ b/src/prediction/mc/gradient_mc.rs
@@ -4,14 +4,14 @@ use crate::fa::{Parameterised, VFunction};
 use crate::geometry::{MatrixView, MatrixViewMut};
 
 pub struct GradientMC<V> {
-    pub v_func: Shared<V>,
+    pub v_func: V,
 
     pub alpha: Parameter,
     pub gamma: Parameter,
 }
 
 impl<V> GradientMC<V> {
-    pub fn new<T1, T2>(v_func: Shared<V>, alpha: T1, gamma: T2) -> Self
+    pub fn new<T1, T2>(v_func: V, alpha: T1, gamma: T2) -> Self
     where
         T1: Into<Parameter>,
         T2: Into<Parameter>,
@@ -42,7 +42,7 @@ impl<S, A, V: VFunction<S>> BatchLearner<S, A> for GradientMC<V> {
             let phi_s = self.v_func.to_features(t.from.state());
             let v_est = self.v_func.evaluate(&phi_s).unwrap();
 
-            self.v_func.borrow_mut().update(&phi_s, self.alpha * (sum - v_est)).ok();
+            self.v_func.update(&phi_s, self.alpha * (sum - v_est)).ok();
         })
     }
 }
@@ -65,6 +65,6 @@ impl<V: Parameterised> Parameterised for GradientMC<V> {
     }
 
     fn weights_view_mut(&mut self) -> MatrixViewMut<f64> {
-        unimplemented!()
+        self.v_func.weights_view_mut()
     }
 }

--- a/src/prediction/td/td.rs
+++ b/src/prediction/td/td.rs
@@ -4,14 +4,14 @@ use crate::fa::{Parameterised, Approximator, VFunction};
 use crate::geometry::{Matrix, MatrixView, MatrixViewMut};
 
 pub struct TD<V> {
-    pub v_func: Shared<V>,
+    pub v_func: V,
 
     pub alpha: Parameter,
     pub gamma: Parameter,
 }
 
 impl<V> TD<V> {
-    pub fn new<T1, T2>(v_func: Shared<V>, alpha: T1, gamma: T2) -> Self
+    pub fn new<T1, T2>(v_func: V, alpha: T1, gamma: T2) -> Self
     where
         T1: Into<Parameter>,
         T2: Into<Parameter>,
@@ -43,7 +43,7 @@ impl<S, A, V: VFunction<S>> OnlineLearner<S, A> for TD<V> {
             t.reward + self.gamma * self.predict_v(t.to.state()) - v
         };
 
-        self.v_func.borrow_mut().update(&phi_s, self.alpha * td_error).ok();
+        self.v_func.update(&phi_s, self.alpha * td_error).ok();
     }
 }
 
@@ -65,6 +65,6 @@ impl<V: Parameterised> Parameterised for TD<V> {
     }
 
     fn weights_view_mut(&mut self) -> MatrixViewMut<f64> {
-        unimplemented!()
+        self.v_func.weights_view_mut()
     }
 }

--- a/src/prediction/td/td_lambda.rs
+++ b/src/prediction/td/td_lambda.rs
@@ -4,7 +4,7 @@ use crate::fa::{Approximator, Parameterised, Projector, Features, VFunction};
 use crate::geometry::{Matrix, MatrixView, MatrixViewMut};
 
 pub struct TDLambda<F> {
-    pub fa_theta: Shared<F>,
+    pub fa_theta: F,
 
     pub alpha: Parameter,
     pub gamma: Parameter,
@@ -14,7 +14,7 @@ pub struct TDLambda<F> {
 
 impl<F> TDLambda<F> {
     pub fn new<T1, T2>(
-        fa_theta: Shared<F>,
+        fa_theta: F,
         trace: Trace,
         alpha: T1,
         gamma: T2,
@@ -60,7 +60,7 @@ impl<S, A, F: VFunction<S>> OnlineLearner<S, A> for TDLambda<F> {
             t.reward + self.gamma * self.predict_v(t.to.state()) - v
         };
 
-        self.fa_theta.borrow_mut().update(&Features::Dense(z), self.alpha * td_error).ok();
+        self.fa_theta.update(&Features::Dense(z), self.alpha * td_error).ok();
     }
 }
 
@@ -82,6 +82,6 @@ impl<F: Parameterised> Parameterised for TDLambda<F> {
     }
 
     fn weights_view_mut(&mut self) -> MatrixViewMut<f64> {
-        unimplemented!()
+        self.fa_theta.weights_view_mut()
     }
 }


### PR DESCRIPTION
During the development of `rsrl` it became clear that you simple cannot realistically have an easy to use *and* general interface without using some dynamic memory management. In many cases we need access to a set of weights in different places that otherwise should be entirely distinct. For example, we may need access to a learnt Q-function instance inside the policy when performing greedy selection. To solve this, we introduced a `Shared<T>` type which combines an `Rc` and `RefCell` to allow mutability and shared access.

The problem: it's messy to have all of these `Shared<T>` types dotted around the codebase. It would be much nicer to abstract over whether the type is shared or not. In this case we get the benefits - no reference counting etc... - of variables that don't need to be shared without preventing general usage.

To solve this, we implement all the various traits on the `Shared<T>` to allow for interoperability. One might argue this was an obvious choice to begin with, but it would be nice if we didn't have to manually update these if interfaces change and/or new interfaces are added. In the end, it's just better to do it like this for now.