### PR TITLE
Make `Shared`'s wrapped value public.

### DIFF
--- a/rsrl/src/memory.rs
+++ b/rsrl/src/memory.rs
@@ -2,7 +2,7 @@ use std::{cell::{RefCell, Ref, RefMut}, fmt, ops::Deref, rc::Rc};
 
 pub fn make_shared<T>(t: T) -> Shared<T> { Shared(Rc::new(RefCell::new(t))) }
 
-pub struct Shared<T>(Rc<RefCell<T>>);
+pub struct Shared<T>(pub Rc<RefCell<T>>);
 
 impl<T> Shared<T> {
     pub fn new(t: T) -> Shared<T> {


### PR DESCRIPTION
Making the contents of `Shared` public is enough to give full access, and it's minimally disruptive to the current codebase. This meets my needs for now, at least until `Shared` can be replaced altogether.